### PR TITLE
XIVY-12538 adapt new 11.2 APIs for ProgrammedStarts

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/CronByGlobalVariableTriggerStartEventBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/CronByGlobalVariableTriggerStartEventBean.java
@@ -23,6 +23,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import ch.ivyteam.ivy.persistence.PersistencyException;
 import ch.ivyteam.ivy.process.eventstart.AbstractProcessStartEventBean;
 import ch.ivyteam.ivy.process.eventstart.IProcessStartEventBeanRuntime;
+import ch.ivyteam.ivy.process.extension.ProgramConfig;
 import ch.ivyteam.ivy.process.extension.ui.ExtensionUiBuilder;
 import ch.ivyteam.ivy.process.extension.ui.IUiFieldEditor;
 import ch.ivyteam.ivy.process.extension.ui.UiEditorExtension;
@@ -48,22 +49,19 @@ public class CronByGlobalVariableTriggerStartEventBean extends AbstractProcessSt
   private static final String RUNTIME_KEY = "eventRuntime";
   private static final Object SYN_OBJECT = new Object();
   private static Map<String, Long> startedJobs = Collections.synchronizedMap(new HashMap<String, Long>());
+  private static final String VARIABLE = "variable";
 
-
-  /**
-   * Default constructor
-   */
   public CronByGlobalVariableTriggerStartEventBean() {
     super("CronTrigger", "Description of CronTrigger");
   }
 
   @Override
-  public void initialize(IProcessStartEventBeanRuntime eventRuntime, String configuration) {
+  public void initialize(IProcessStartEventBeanRuntime eventRuntime, ProgramConfig configuration) {
     super.initialize(eventRuntime, configuration);
     // Disable Ivy polling
     eventRuntime.poll().disable();
     try {
-      Variable var = Variables.of(eventRuntime.getProcessModelVersion().getApplication()).variable(configuration);
+      Variable var = Variables.of(eventRuntime.getProcessModelVersion().getApplication()).variable(configuration.get(VARIABLE));
       if (var != null) {
         String pattern = var.value();
         SchedulerFactory sf = new StdSchedulerFactory();
@@ -176,21 +174,9 @@ public class CronByGlobalVariableTriggerStartEventBean extends AbstractProcessSt
    */
   public static class Editor extends UiEditorExtension {
 
-    private IUiFieldEditor globalVariable;
-
-    @Override
+	@Override
     public void initUiFields(ExtensionUiBuilder ui) {
-      globalVariable = ui.textField().create();
-    }
-
-    @Override
-    public String getConfiguration() {
-      return globalVariable.getText();
-    }
-
-    @Override
-    public void setConfiguration(String configString) {
-      globalVariable.setText(configString);
+      ui.textField(VARIABLE).create();
     }
   }
 }


### PR DESCRIPTION
adapt the program start to the latest core APIs: please verify it and include it in your sprint release.
we wrote in the core a json-conversion, that will handle this cron bean and automatically transform the 'userConfig' onto the introduced 'variables' configuration key.