### PR TITLE
bug/IVYPORTAL-15957-Widget-name-too-long-break-layout-FOR_MASTER

### DIFF
--- a/AxonIvyPortal/portal/webContent/resources/css/dashboard.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/dashboard.css
@@ -804,6 +804,7 @@ body .ui-widget.new-widget-dialog__widget-name {
   text-overflow: ellipsis;
   white-space: nowrap;
   display: block;
+  max-width: 20vw;
 }
 
 body .ui-widget.new-widget-dialog__introduction {


### PR DESCRIPTION
- fix widget long name break layout