### PR TITLE
Replace ugly _event methods with event method

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/dto/IvyNotificationChannelDTO.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/dto/IvyNotificationChannelDTO.java
@@ -32,7 +32,7 @@ public class IvyNotificationChannelDTO {
 
   private static IvyNotificationChannelDTO toChannel(ISecurityMember subscriber, NotificationChannel channel) {
     var subscriptions = channel.configFor(subscriber).subscriptions().stream()
-        .collect(Collectors.toMap(NotificationSubscription::_event,
+        .collect(Collectors.toMap(NotificationSubscription::event,
             subscription -> new IvyNotificationChannelSubcriptionDTO(subscription.state(),
                 subscription.isSubscribedByDefault())));
     return new IvyNotificationChannelDTO(channel, subscriptions);


### PR DESCRIPTION
This is the second step of the new Notification Event API change. 
Replace ugly _event() method with the new event() method.