### PR TITLE
streamline security.md with axonivy-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@ See the [Axon Ivy Portal on the Axon Ivy Market](https://market.axonivy.com/port
 ## License
 
 See the [LICENSE](LICENSE) file for license rights and limitations (Apache License 2.0).
+
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 11.x.x  | :white_check_mark: |
+| 10.0.x  | :white_check_mark:  |
+|  8.0.x   | :white_check_mark: |
+| <= 7.x.x   | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,3 @@
-# Security Policy
-
-## Supported Versions
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 11.x.x  | :white_check_mark: |
-| 10.0.x  | :white_check_mark:  |
-|  8.0.x   | :white_check_mark: |
-| <= 7.x.x   | :x:                |
-
 ## Reporting a Vulnerability
 
 At Axon Ivy, we take security seriously. If you believe you've found a security vulnerability in our software, we encourage you to let us know right away. We investigate all reported vulnerabilities promptly.
@@ -24,7 +13,7 @@ Please refrain from publicly disclosing the vulnerability until it has been addr
 ## Response Time
 
 We strive to respond to security vulnerability reports as quickly as possible. Upon receiving your report, we will acknowledge it within 72 hours and we will release a patch as soon as possible depending on complexity, but historically within a few days.
-Please report (suspected) security vulnerabilities at https://support.axonivy.com/ . 
+Please report (suspected) security vulnerabilities at https://support.axonivy.com/.
 
 
 ## Responsible Disclosure


### PR DESCRIPTION
we have a failing build, which checks that all security.md files are equal throughout the axonivy-org.
the template is this here: https://github.com/axonivy/github-repo-manager/blob/master/SECURITY.md
therefore I'd vote to move the 'supported-version' section to another file.
