### PR TITLE
MARP-620 Add release-drafter workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,7 +3,7 @@ name: Publish Release
 on:
   push:
     tags:
-      - v*.*.*
+      - "v*.*.*"
 
 permissions:
   contents: write

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,18 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  build:
+    uses: axonivy-market/github-workflows/.github/workflows/publish-release.yml@v4
+    # The 'publish_release' input parameter is used to control whether the release should be published automatically.
+    # Uncomment and set to 'false' if you want to prevent the release from being published immediately.
+    # with:
+    #   publish_release: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,4 @@
 name: Release Drafter
-
 on:
   push:
     branches:
@@ -7,7 +6,21 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
-
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+      prerelease:
+        description: 'Is this a prerelease?'
+        required: false
+        default: false
+        type: boolean
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/release-drafter.yml@v4
+    with:
+      version: ${{ github.event.inputs.version }}
+      prerelease: ${{ github.event.inputs.prerelease }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,26 +1,16 @@
 name: Release Drafter
+
 on:
   push:
     branches:
       - master
   pull_request:
     types: [opened, reopened, synchronize]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version'
-        required: true
-      prerelease:
-        description: 'Is this a prerelease?'
-        required: false
-        default: false
-        type: boolean
+
 permissions:
   contents: write
   pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/release-drafter.yml@v4
-    with:
-      version: ${{ github.event.inputs.version }}
-      prerelease: ${{ github.event.inputs.prerelease }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,13 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: axonivy-market/github-workflows/.github/workflows/release-drafter.yml@v4


### PR DESCRIPTION
Hi anh @lttung-axonivy, in this PR, I've integrated two release workflows:

1. **Publish Release:** This workflow runs automatically after a new tag is pushed.
2. **Release Drafter:** This workflow drafts the next release whenever a PR is merged into the master branch. It also triggers the automatic labeling process for PRs.

Could you please review and provide your feedback?

Thank you!
