### PR TITLE
distribute portal-components as JAR

### DIFF
--- a/AxonIvyPortal/portal-components/jar.xml
+++ b/AxonIvyPortal/portal-components/jar.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="https://maven.apache.org/xsd/assembly-2.1.1.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/xsd/assembly-2.1.1.xsd">
+  <id>jar</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <fileSets>
+    <fileSet>
+      <directory>./target/classes</directory>
+      <excludes>
+        <exclude>META-INF/</exclude>
+      </excludes>
+      <outputDirectory></outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/AxonIvyPortal/portal-components/pom.xml
+++ b/AxonIvyPortal/portal-components/pom.xml
@@ -52,6 +52,7 @@
     </pluginRepository>
   </pluginRepositories>
   <build>
+    <sourceDirectory>src</sourceDirectory>
     <plugins>
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
@@ -61,6 +62,37 @@
         <configuration>
           <compilerWarnings>false</compilerWarnings>
         </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.4.2</version>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>jar.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
this publishes the java code in portal-components as JAR and also its sources.
A customer is asking for this, in order that he can build javadocs for his own solution, that depends upon portal-components.
https://axonivy.zendesk.com/agent/tickets/4928