### PR TITLE
feature/IVYPORTAL-18028-High-Failure-to-use-HTTPS-or-SFTP-URL-in-Mave…

### DIFF
--- a/AxonIvyPortal/portal-product/pom.xml
+++ b/AxonIvyPortal/portal-product/pom.xml
@@ -24,7 +24,7 @@
       </releases>
       <name>Axonivy Repo</name>
       <id>release-repo</id>
-      <url>http://repo.axonivy.com/artifactory/libs-release/</url>
+      <url>https://repo.axonivy.com/artifactory/libs-release/</url>
       <layout>default</layout>
     </repository>
     <repository>
@@ -35,7 +35,7 @@
       </snapshots>
       <name>Axonivy Repo</name>
       <id>snapshots-repo</id>
-      <url>http://repo.axonivy.com/artifactory/libs-snapshot/</url>
+      <url>https://repo.axonivy.com/artifactory/libs-snapshot/</url>
       <layout>default</layout>
     </repository>
   </repositories>


### PR DESCRIPTION
- Use HTTPS URL in maven artifact download