### PR TITLE
XIVY-1259 Fix filter for system task

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/TaskService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/TaskService.java
@@ -95,7 +95,7 @@ public class TaskService {
   }
   
   protected TaskQuery queryExcludeSystemTasks() {
-    return TaskQuery.create().where().workerId().isNotEqual(ISecurityContext.current().users().system().getSecurityMemberId());
+    return TaskQuery.create().where().workerId().isNotEqual(ISecurityContext.current().users().system().getSecurityMemberId()).or().workerId().isNull();
   }
 
   protected TaskQuery queryExcludeHiddenTasks() {


### PR DESCRIPTION
If you fire a query with NOT EQUAL `<>` then you
will never match `NULL`, because this is SQL standard.

If you want to match all `NULL` values too, then you need add it as additional `OR` filter. This probably has never worked properley. But in past, before multiple responsibles, we have mis-used the field `worker` in the database to get performance improvements.