### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cron-bot.yml
+++ b/.github/workflows/cron-bot.yml
@@ -1,5 +1,7 @@
 name: Cron Bot
 run-name: 🤖 Cron Bot
+permissions:
+  contents: write
 on:
   schedule:
     # Cron at midnight GMT+7


### PR DESCRIPTION
Potential fix for [https://github.com/axonivy-market/portal/security/code-scanning/45](https://github.com/axonivy-market/portal/security/code-scanning/45)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow uses `github.rest.actions.createWorkflowDispatch`, it requires `contents: write` permission. We will add a `permissions` block at the root level of the workflow to apply the least privilege required for all jobs. This ensures that the workflow has only the necessary permissions and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
