### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -1,5 +1,7 @@
 name: Lighthouse Audit
 run-name: 🗼Lighthouse Audit
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/axonivy-market/portal/security/code-scanning/31](https://github.com/axonivy-market/portal/security/code-scanning/31)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out code, downloading files, and uploading artifacts). Therefore, the `contents: read` permission is sufficient. If any step requires additional permissions in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
