### PR TITLE
MARP-2409 German translation for Portal on the MarketPlace website

### DIFF
--- a/AxonIvyPortal/portal-product/zip.xml
+++ b/AxonIvyPortal/portal-product/zip.xml
@@ -11,7 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>


### PR DESCRIPTION
Hi Wawa team,
Sabine introduced the German translation for the Portal last year, but it has not yet been supported in the zip.xml file.
So we want to enhance the zip.xml file.
![image](https://github.com/user-attachments/assets/4a9d3557-fdd0-4df2-a319-4726adc6fc4d)
Could you please review and merge it?