### PR TITLE
IVYPORTAL-19332 Leave datetime pattern as placeholder for datetime input

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DateTimePatternBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DateTimePatternBean.java
@@ -23,6 +23,14 @@ public class DateTimePatternBean implements Serializable {
   public String getDatePattern() {
     return dateTimePatternService.getDatePattern();
   }
+  
+  public String getShortDatePattern() {
+    return dateTimePatternService.getDatePatternForDatePicker();
+  }
+
+  public String getShortDateTimePattern(boolean isDateFilter) {
+    return dateTimePatternService.getDateTimePatternForDatePicker(isDateFilter);
+  }
 
   public String getDateTimePattern() {
     return dateTimePatternService.getDateTimePattern();

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/DateTimeGlobalSettingService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/DateTimeGlobalSettingService.java
@@ -72,4 +72,31 @@ public class DateTimeGlobalSettingService {
     return ((SimpleDateFormat) getDefaultDateFormatter()).toPattern();
   }
 
+  public String getDateTimePatternForDatePicker(boolean isDateFilter) {
+    return isYearHidden() ? getDateWithoutYearPattern(getDefaultDateTimePattern(isDateFilter, DateFormat.SHORT)) :
+            getDefaultDateTimePattern(isDateFilter, DateFormat.SHORT);
+  }
+  
+  public String getDatePatternForDatePicker() {
+	return isYearHidden() ? getDateWithoutYearPattern(getDefaultDatePattern(DateFormat.SHORT)) :
+            getDefaultDatePattern(DateFormat.SHORT);
+  }
+
+  private DateFormat getDefaultDateFormatter(int dateFormat) {
+    return DateFormat.getDateInstance(dateFormat, Ivy.session().getFormattingLocale());
+  }
+  
+  private String getDefaultDatePattern(int dateFormat) {
+	return ((SimpleDateFormat) getDefaultDateFormatter(dateFormat)).toPattern().replaceAll("y+", "yyyy");
+  }
+
+  private String getDefaultDateTimePattern(boolean isDateFilter, int dateFormat) {
+    String pattern = ((SimpleDateFormat) getDefaultDateFormatter(dateFormat)).toPattern().replaceAll("y+", "yyyy");
+    
+    if (isDateFilter) {
+    	return isDateFilterWithTime() ? pattern + SPACE_CHARACTER + Ivy.cms().co("/patterns/timePattern") : pattern;
+    }
+    
+    return !isTimeHidden() ? pattern + SPACE_CHARACTER + Ivy.cms().co("/patterns/timePattern") : pattern;
+  }
 }

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomWidgetConfiguration/CustomWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomWidgetConfiguration/CustomWidgetConfiguration.xhtml
@@ -122,7 +122,8 @@
                 rendered="#{parameter.type == 'DATE'}"
                 locale="#{localeBean.locale}"
                 showTime="#{!dateTimePatternBean.isTimeHidden}"
-                showIcon="true" />
+                showIcon="true"
+                placeholder="#{dateTimePatternBean.getShortDateTimePattern(false)}" />
               <ic:com.axonivy.portal.components.UserSelection
                 id="param-user-#{status.index}"
                 selectedUser="#{parameter.valueUser}"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/AbsenceManagement/Absence.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/AbsenceManagement/Absence.xhtml
@@ -47,7 +47,8 @@
           <h:outputLabel for="absence-start-date" styleClass="ui-g-12"
             value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/AbsenceAndDeputy/from')}:" />
           <div class="ui-g-12">
-            <p:datePicker id="absence-start-date" value="#{data.selectedAbsence.from}" 
+            <p:datePicker id="absence-start-date" value="#{data.selectedAbsence.from}"
+              placeholder="#{dateTimePatternBean.shortDatePattern}"
               locale="#{localeBean.locale}"
               showIcon="true" converterMessage="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/wrongDateFormat')}"
               required="true"
@@ -63,6 +64,7 @@
             value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/AbsenceAndDeputy/till')}:" />
           <div class="ui-g-12">
             <p:datePicker id="absence-end-date" value="#{data.selectedAbsence.until}" showIcon="true"
+            	placeholder="#{dateTimePatternBean.shortDatePattern}"
               locale="#{localeBean.locale}"
               required="true"
               converterMessage="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/wrongDateFormat')}"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskItemGeneralInfo/TaskItemGeneralInfo.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskItemGeneralInfo/TaskItemGeneralInfo.xhtml
@@ -208,7 +208,8 @@
               <p:ajax event="save" listener="#{logic.updateDelayTimestamp(task)}"
                 update="delay-form #{cc.clientId}:task-detail-state #{cc.attrs.componentToUpdate}" resetValues="true" />
               <p:datePicker id="delay-date-calendar" styleClass="delay-date-calendar" value="#{task.delayTimestamp}"
-                showTime="#{!dateTimePatternBean.isTimeHidden}"  locale="#{localeBean.locale}" >
+                showTime="#{!dateTimePatternBean.isTimeHidden}"  locale="#{localeBean.locale}"
+                placeholder="#{dateTimePatternBean.getShortDateTimePattern(false)}" >
                 <f:validator validatorId="taskDelayTimestampValidator" />
               </p:datePicker>
             </p:inplace>
@@ -238,7 +239,8 @@
                 <p:ajax event="save" listener="#{logic.updateExpiryTime(task)}"
                   update="expiry-form #{cc.attrs.componentToUpdate}" process="@this expiry-calendar"/>
                 <p:datePicker id="expiry-calendar" styleClass="task-details-data-expiry" value="#{data.expiryTimestamp}"
-                  showTime="#{!dateTimePatternBean.isTimeHidden}" locale="#{localeBean.locale}" >
+                  showTime="#{!dateTimePatternBean.isTimeHidden}" locale="#{localeBean.locale}"
+                  placeholder="#{dateTimePatternBean.getShortDateTimePattern(false)}" >
                   <f:validator validatorId="taskExpiryTimestampValidator" />
                 </p:datePicker>
               </p:inplace>

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/DateFilter/DateFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/DateFilter/DateFilter.xhtml
@@ -51,7 +51,8 @@
     styleClass="ui-fluid md-inputfield date-picker-panel">
     <p:datePicker id="is-not-date" value="#{filter.fromDate}" locale="#{localeBean.locale}" disabled="#{readOnly}"
       onkeypress="if (event.keyCode == 13) { return false; }" showTime="#{dateTimePatternBean.isDateFilterWithTime}"
-      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}">
+      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}"
+      placeholder="#{dateTimePatternBean.getShortDateTimePattern(true)}">
       <p:ajax event="close" partialSubmit="true" global="false" listener="#{widgetDateFilterBean.updateFromDate(filter)}" />
       <f:param name="skipValidator" value="true" />
       <f:validator validatorId="dashboardDateFilterValidator" disabled="#{param['skipValidator'] == 'true'}" />
@@ -66,7 +67,8 @@
     styleClass="ui-fluid md-inputfield date-picker-panel">
     <p:datePicker id="before-date" value="#{filter.fromDate}" locale="#{localeBean.locale}" disabled="#{readOnly}"
       onkeypress="if (event.keyCode == 13) { return false; }" showTime="#{dateTimePatternBean.isDateFilterWithTime}"
-      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}">
+      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}"
+      placeholder="#{dateTimePatternBean.getShortDateTimePattern(true)}">
       <p:ajax event="close" partialSubmit="true" global="false" listener="#{widgetDateFilterBean.updateFromDate(filter)}" />
       <f:param name="skipValidator" value="true" />
       <f:validator validatorId="dashboardDateFilterValidator" disabled="#{param['skipValidator'] == 'true'}" />
@@ -81,7 +83,8 @@
     styleClass="ui-fluid md-inputfield date-picker-panel">
     <p:datePicker id="after-date" value="#{filter.toDate}" locale="#{localeBean.locale}" disabled="#{readOnly}"
       onkeypress="if (event.keyCode == 13) { return false; }" showTime="#{dateTimePatternBean.isDateFilterWithTime}"
-      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}">
+      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}"
+      placeholder="#{dateTimePatternBean.getShortDateTimePattern(true)}">
       <p:ajax event="close" partialSubmit="true" global="false" listener="#{widgetDateFilterBean.updateToDate(filter)}" />
       <f:param name="skipValidator" value="true" />
       <f:validator validatorId="dashboardDateFilterValidator" disabled="#{param['skipValidator'] == 'true'}" />
@@ -97,7 +100,8 @@
     styleClass="ui-fluid md-inputfield date-picker-panel">
     <p:datePicker id="from-date" value="#{filter.fromDate}" locale="#{localeBean.locale}" disabled="#{readOnly}"
       onkeypress="if (event.keyCode == 13) { return false; }" showTime="#{dateTimePatternBean.isDateFilterWithTime}"
-      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}">
+      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}"
+      placeholder="#{dateTimePatternBean.getShortDateTimePattern(true)}">
       <p:ajax event="close" partialSubmit="true" global="false" listener="#{widgetDateFilterBean.updateFromDate(filter)}" />
       <f:param name="skipValidator" value="true" />
       <f:validator validatorId="dashboardDateFilterValidator" disabled="#{param['skipValidator'] == 'true'}" />
@@ -116,7 +120,8 @@
     rendered="#{filter.operator == 'BETWEEN' || filter.operator == 'NOT_BETWEEN'}"
     styleClass="ui-fluid md-inputfield date-picker-panel">
     <p:datePicker id="to-date" value="#{filter.toDate}" locale="#{localeBean.locale}" disabled="#{readOnly}" showTime="#{dateTimePatternBean.isDateFilterWithTime}"
-      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}">
+      showIcon="true" converterMessage="#{widgetDateFilterBean.getWrongFormatMessage(filter.field, filterIndex, widget)}"
+      placeholder="#{dateTimePatternBean.getShortDateTimePattern(true)}">
       <p:ajax event="close" partialSubmit="true" global="false" listener="#{widgetDateFilterBean.updateToDate(filter)}" />
       <f:param name="skipValidator" value="true" />
       <f:validator validatorId="dashboardDateFilterValidator" disabled="#{param['skipValidator'] == 'true'}" />


### PR DESCRIPTION
- Update DateTimePatternBean and DateTimeGlobalSettingService to get short datetime pattern.
- Update xhtml files to shoe the placeholder in datePicker components.