### PR TITLE
XIVY-17282 Fix IvyComponentLogicCaller after adjustments in the core

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/IvyComponentLogicCaller.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/IvyComponentLogicCaller.java
@@ -47,9 +47,11 @@ public class IvyComponentLogicCaller<T> {
    */
   private void setTargetComponent(MethodExpression componentMethod, UIComponent component) {
     try {
+      var getCompositeComponentId = component.getClass().getDeclaredMethod("getCompositeComponentId");
+      var compositeComponentId = getCompositeComponentId.invoke(component);
       Field cc = componentMethod.getClass().getDeclaredField("compositeComponentId");
       cc.setAccessible(true);
-      cc.set(componentMethod, component.getId());
+      cc.set(componentMethod, compositeComponentId);
     } catch (Exception ex) {
       Ivy.log().error(ex);
     }


### PR DESCRIPTION
We improved the PrimeFaces Dialog Framework so it can now be used within Composite Components.
[Commit 1](https://github.com/axonivy/core/commit/57dfd68d02ab144abe2d1c665f462ee5d6792fbf)
[Commit 2](https://github.com/axonivy/core/commit/b74bbf1c458841c078dff62c04b11f7fd60a7672)

To make this work (especially for nested components) we had to adjust the compositeComponentId (see Commit 2). Due to these changes, your hack within the `IvyComponentLogicCaller` for locating the corresponding component to execute the desired logic no longer worked.

This update should fix the issue.