### PR TITLE
IVYPORTAL-20222 Remove duplicate language entries when loading dashboard configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ AxonIvyPortal/PortalKitTestHelper/src_dataClasses/
 Showcase/InternalSupport/src_dataClasses/
 Showcase/InternalSupport/target/
 **/.flattened-pom.xml
+**/target/
+**/logs/
+**/mvn-deps/
+.vscode
+AxonIvyPortal/portal/bin/src_dataClasses/

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,3 @@ AxonIvyPortal/AxonIvyExpress/src_dataClasses/
 AxonIvyPortal/PortalKitTestHelper/src_dataClasses/
 Showcase/InternalSupport/src_dataClasses/
 Showcase/InternalSupport/target/
-**/.flattened-pom.xml
-**/target/
-**/logs/
-**/mvn-deps/
-.vscode
-AxonIvyPortal/portal/bin/src_dataClasses/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ AxonIvyPortal/AxonIvyExpress/src_dataClasses/
 AxonIvyPortal/PortalKitTestHelper/src_dataClasses/
 Showcase/InternalSupport/src_dataClasses/
 Showcase/InternalSupport/target/
+**/.flattened-pom.xml

--- a/AxonIvyPortal/portal-selenium-test/resources/testFile/Dashboard_With_Duplicate_Locales.json
+++ b/AxonIvyPortal/portal-selenium-test/resources/testFile/Dashboard_With_Duplicate_Locales.json
@@ -1,0 +1,127 @@
+[
+  {
+    "id": "duplicate-test-dashboard",
+    "version": "13.1.0",
+    "templateId": "create-from-scratch",
+    "titles": [
+      {
+        "locale": "en",
+        "value": "Dashboard with Duplicates"
+      },
+      {
+        "locale": "en",
+        "value": "Duplicate English Entry"
+      },
+      {
+        "locale": "fr",
+        "value": "Tableau de bord"
+      },
+      {
+        "locale": "de",
+        "value": "Dashboard"
+      },
+      {
+        "locale": "de",
+        "value": "Duplicate German Entry"
+      }
+    ],
+    "icon": "fa-warning",
+    "widgets": [
+      {
+        "type": "task",
+        "id": "task_duplicate_test",
+        "names": [
+          {
+            "locale": "en",
+            "value": "Your Tasks"
+          },
+          {
+            "locale": "en",
+            "value": "Duplicate English Widget Name"
+          },
+          {
+            "locale": "de",
+            "value": "Ihre Aufgaben"
+          },
+          {
+            "locale": "fr",
+            "value": "Vos tâches"
+          },
+          {
+            "locale": "fr",
+            "value": "Duplicate French Widget Name"
+          }
+        ],
+        "layout": {
+          "w": 12,
+          "h": 5,
+          "x": 0,
+          "y": 0
+        },
+        "rowsPerPage": 5,
+        "canWorkOn": true,
+        "sortField": "startTimestamp",
+        "sortDescending": true,
+        "columns": [
+          {
+            "field": "name"
+          },
+          {
+            "field": "priority"
+          },
+          {
+            "field": "state"
+          },
+          {
+            "field": "actions"
+          }
+        ]
+      },
+      {
+        "type": "case",
+        "id": "case_duplicate_test",
+        "names": [
+          {
+            "locale": "en",
+            "value": "Your Cases"
+          },
+          {
+            "locale": "de",
+            "value": "Ihre Vorgänge"
+          },
+          {
+            "locale": "de",
+            "value": "Duplicate German Case Widget"
+          },
+          {
+            "locale": "es",
+            "value": "Sus casos"
+          }
+        ],
+        "layout": {
+          "w": 12,
+          "h": 5,
+          "x": 0,
+          "y": 5
+        },
+        "rowsPerPage": 5,
+        "sortField": "startTimestamp",
+        "sortDescending": true,
+        "columns": [
+          {
+            "field": "id"
+          },
+          {
+            "field": "name"
+          },
+          {
+            "field": "state"
+          },
+          {
+            "field": "actions"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/DashboardConfigurationPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/DashboardConfigurationPage.java
@@ -14,6 +14,7 @@ import org.openqa.selenium.interactions.Actions;
 import com.axonivy.portal.selenium.common.FileHelper;
 import com.axonivy.portal.selenium.common.Sleeper;
 import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import com.codeborne.selenide.WebDriverRunner;
 
@@ -350,6 +351,13 @@ public class DashboardConfigurationPage extends TemplatePage {
 
     multipleLanguageDialog.$("button[type='submit']").click();
     multipleLanguageDialog.shouldBe(Condition.disappear, DEFAULT_TIMEOUT);
+  }
+
+  public ElementsCollection getMultiLangDashboardImportTitle() {
+    getAddLanguageButton().click();
+    var multipleLanguageDialog = getImportMultipleLanguageDialog();
+    var elementsInput = multipleLanguageDialog.$$("td input");
+    return elementsInput;
   }
 
   private SelenideElement findPrivateDashboardRowByName(String dashboardName) {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/dashboard/DashboardConfigurationTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/dashboard/DashboardConfigurationTest.java
@@ -475,6 +475,45 @@ public class DashboardConfigurationTest extends BaseTest {
   }
 
   @Test
+  public void testImportDashboardWithDuplicateLocales() {
+    redirectToRelativeLink(grantDashboardImportOwnPermissionUrl);
+    LinkNavigator.redirectToPortalDashboardConfiguration();
+    var configurationPage = new DashboardConfigurationPage();
+    configurationPage.openCreatePrivateDashboardMenu();
+    configurationPage.getImportDashboardDialog();
+
+    configurationPage.uploadFile("Dashboard_With_Duplicate_Locales.json");
+    configurationPage.getDashboardImportSaveButton().shouldBe(Condition.enabled, DEFAULT_TIMEOUT);
+
+    var titles = configurationPage.getMultiLangDashboardImportTitle();
+    titles.get(0).shouldHave(Condition.value("Dashboard with Duplicates"));
+    titles.get(2).shouldHave(Condition.value("Dashboard"));
+
+    configurationPage.getImportMultipleLanguageDialog().$("button[type='submit']").click();
+
+    String name = "Imported Duplicate Dashboard";
+    String newGermanName = "German Duplicate Dashboard";
+    String icon = "fa-warning";
+    String description = "Dashboard imported from JSON with duplicate locales";
+
+    configurationPage.saveImportDashboard(name, newGermanName, description, icon);
+
+    NewDashboardDetailsEditPage newDashboardDetailsEditPage = new NewDashboardDetailsEditPage();
+    newDashboardDetailsEditPage.getTitleByIndex(0).shouldBe(Condition.exactText(name));
+    newDashboardDetailsEditPage.getIconByIndex(0, icon).shouldBe(Condition.appear);
+
+    newDashboardDetailsEditPage.getWidgets().shouldBe(CollectionCondition.size(2));
+
+    SelenideElement taskWidgetTitle = newDashboardDetailsEditPage.getWidgets().get(0).$("span.widget__header-title");
+    taskWidgetTitle.shouldHave(Condition.text("Your Tasks"));
+
+    SelenideElement caseWidgetTitle = newDashboardDetailsEditPage.getWidgets().get(1).$("span.widget__header-title");
+    caseWidgetTitle.shouldHave(Condition.text("Your Cases"));
+
+    goBackConfigurationAndVerifyDashboards(name, description, newDashboardDetailsEditPage, false);
+  }
+
+  @Test
   public void testImportPublicDashboard() {
     redirectToRelativeLink(grantDashboardImportPublicPermissionUrl);
     LinkNavigator.redirectToPortalDashboardConfiguration();
@@ -498,7 +537,7 @@ public class DashboardConfigurationTest extends BaseTest {
   }
   
   @Test
-  public void testAddNewAcccessibilityDashboard() {
+  public void testAddNewAccessibilityDashboard() {
     String name = "Accessibility shortcuts dashboard";
     String icon = "fa-coffee";
     String description = "Accessibility shortcuts dashboard description";

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardModificationBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardModificationBean.java
@@ -8,11 +8,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.faces.bean.ManagedBean;
@@ -247,7 +249,7 @@ public class DashboardModificationBean extends DashboardBean implements Serializ
   public void updateDashboardTitleByLocale() {
     String currentTitle = this.selectedDashboard.getTitle();
     initMultipleLanguagesForDashboardName(currentTitle);
-    String currentLanguage = UserUtils.getUserLanguage();
+    String currentLanguage = Locale.forLanguageTag(UserUtils.getUserLanguage()).getLanguage();
     Optional<DisplayName> optional = this.selectedDashboard.getTitles().stream()
         .filter(lang -> currentLanguage.equals(lang.getLocale().getLanguage())).findFirst();
     if (optional.isPresent()) {
@@ -257,7 +259,7 @@ public class DashboardModificationBean extends DashboardBean implements Serializ
 
   public void updateCurrentLanguage() {
     List<DisplayName> languages = this.selectedDashboard.getTitles();
-    String currentLanguage = UserUtils.getUserLanguage();
+    String currentLanguage = Locale.forLanguageTag(UserUtils.getUserLanguage()).getLanguage();
     Optional<DisplayName> optional = languages.stream()
         .filter(lang -> currentLanguage.equals(lang.getLocale().getLanguage()))
         .findFirst();
@@ -279,19 +281,30 @@ public class DashboardModificationBean extends DashboardBean implements Serializ
         this.selectedDashboard.getTitles().add(displayName);
       }
     }
+    deduplicateTitles();
     return this.selectedDashboard.getTitles();
+  }
+
+  private void deduplicateTitles() {
+    List<DisplayName> titles = this.selectedDashboard.getTitles();
+    Set<String> seen = new LinkedHashSet<>();
+    titles.removeIf(title -> title.getLocale() == null || !seen.add(title.getLocale().getLanguage()));
   }
 
   private Map<String, DisplayName> getMapLanguages() {
     List<DisplayName> languages = this.selectedDashboard.getTitles();
-    return languages.stream().collect(Collectors.toMap(o -> o.getLocale().toLanguageTag(), o -> o));
+    return languages.stream()
+        .filter(o -> o.getLocale() != null)
+        .collect(Collectors.toMap(o -> o.getLocale().getLanguage(), o -> o, (existing, replacement) -> existing));
   }
 
   private void initMultipleLanguagesForDashboardName(String currentTitle) {
+    deduplicateTitles();
     Map<String, DisplayName> mapLanguage = getMapLanguages();
     List<String> supportedLanguages = getSupportedLanguages();
     for (String language : supportedLanguages) {
-      DisplayName localeLanguage = mapLanguage.get(language);
+      String langCode = Locale.forLanguageTag(language).getLanguage();
+      DisplayName localeLanguage = mapLanguage.get(langCode);
       if (localeLanguage == null) {
         DisplayName displayName = new DisplayName();
         displayName.setLocale(Locale.forLanguageTag(language));


### PR DESCRIPTION
## Summary

- Cherry-pick of #3109 targeting `release/12.0`
- Fixes `IllegalStateException` caused by duplicate locale keys when loading dashboard configuration with duplicate language entries
- Adds deduplication logic in `DashboardModificationBean` and improves language code comparison using `Locale.forLanguageTag`
- Adds test case `testImportDashboardWithDuplicateLocales` and supporting test data file

## Changes

- `DashboardModificationBean.java` — add `deduplicateTitles()`, fix `getMapLanguages()` with merge function and null-locale filter, normalize language comparison via `Locale.forLanguageTag`
- `DashboardConfigurationPage.java` — add `uploadFile` and import-related helper methods
- `DashboardConfigurationTest.java` — add `testImportDashboardWithDuplicateLocales` test
- `Dashboard_With_Duplicate_Locales.json` — new test fixture with duplicate locale entries
- `.gitignore` — add common ignore patterns

## Test plan

- [ ] Import a dashboard JSON file with duplicate language entries — should not throw `IllegalStateException`
- [ ] Verify widget names and dashboard titles display correctly after import with duplicate locales
- [ ] Run `testImportDashboardWithDuplicateLocales` selenium test

Cherry-picked from: #3109 (commit 76ccfd66e89ab95abb0bae91e165a60bf17df133)