### PR TITLE
IVYPORTAL-20323 Fix failed tests after convert projects

### DIFF
--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/BaseTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/BaseTest.java
@@ -71,7 +71,7 @@ public class BaseTest {
   protected String businessCaseUrl = "internalSupport/15B1EA24CCF377E8/updateCheckInTime.ivp";
   protected String hideCaseUrl = "portal-developer-examples/16583F0F73864543/createHiddenTechnicalCase.ivp";
   protected String createSystemTaskUrl = "portal-developer-examples/16583F0F73864543/createSystemTask.ivp";
-  protected String createTestingCaseMapUrl = "internalSupport/764871e4-cf70-401f-83fb-9e99fa897fc4.icm";
+  protected String createTestingCaseMapUrl = "internalSupport/764871e4-cf70-401f-83fb-9e99fa897fc4.m.json";
   protected String createTestingCaseUrlForCustomizationAdditionalCaseDetails =
       "portal-components-examples/176465FBFE257CF3/createInvestmentRequest.ivp";
   protected String createTestingCaseUrlForDefaultAdditionalCaseDetails =

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/UrlHelpers.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/UrlHelpers.java
@@ -19,7 +19,7 @@ public class UrlHelpers {
         && !relativeProcessStartLink.contains("portal-components-examples")) {
       relativeProcessStartLink = WordUtils.capitalize(relativeProcessStartLink);
     }
-    if (relativeProcessStartLink.endsWith(".icm")) {
+    if (relativeProcessStartLink.endsWith(".icm") || relativeProcessStartLink.endsWith(".m.json")) {
       return getEngineUrl() + getApplicationName() + "/casemap/" + relativeProcessStartLink;
     }
     return getEngineUrl() + getApplicationName() + "/pro/" + relativeProcessStartLink;

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/document/screenshot/DemoProcessesScreenshotTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/document/screenshot/DemoProcessesScreenshotTest.java
@@ -22,7 +22,7 @@ import com.axonivy.portal.selenium.page.TopMenuTaskWidgetPage;
 public class DemoProcessesScreenshotTest extends ScreenshotBaseTest {
 
   private static String LEAVE_REQUEST_START_LINK = "portal-user-examples/170321BD7F5539D6/start.ivp";
-  private static final String CASE_MAP_URL = "/portal-user-examples/70765b37-a3e8-418a-a8d5-c2b3a539408e.icm";
+  private static final String CASE_MAP_URL = "/portal-user-examples/70765b37-a3e8-418a-a8d5-c2b3a539408e.m.json";
 
   private MainMenuPage mainMenuPage;
   // private ExampleOverviewPage exampleOverviewPage;

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/userexample/test/CaseMapTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/userexample/test/CaseMapTest.java
@@ -18,7 +18,7 @@ import com.codeborne.selenide.Condition;
 public class CaseMapTest extends BaseTest {
 
   private static final String CREATE_CONTRACT = "Create Contract";
-  private static final String CASE_MAP_URL = "/portal-user-examples/70765b37-a3e8-418a-a8d5-c2b3a539408e.icm";
+  private static final String CASE_MAP_URL = "/portal-user-examples/70765b37-a3e8-418a-a8d5-c2b3a539408e.m.json";
   private static final String VERIFY_PERSONAL_DATA = "Verify Personal Data";
   private static final String INTERNAL_SOLVENCY_CHECK = "Internal Solvency Check";
   private static final String APPROVAL_LEVEL_1 = "Approve Level 1";

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/AbstractProcessBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/AbstractProcessBean.java
@@ -35,6 +35,7 @@ public abstract class AbstractProcessBean implements Serializable {
   protected static final String UNDERSCORE_BLANK = "_blank";
   protected static final String UNDERSCORE_SELF  = "_self";
   protected static final String DOT_ICM  = ".icm";
+  protected static final String DOT_M_JSON = ".m.json";
   private List<Process> portalProcesses;
 
   public synchronized void init() {
@@ -101,7 +102,7 @@ public abstract class AbstractProcessBean implements Serializable {
   }
 
   public boolean isCaseMap(Process process) {
-    return !Objects.isNull(process) && process.getStartLink().endsWith(DOT_ICM);
+    return !Objects.isNull(process) && (process.getStartLink().endsWith(DOT_ICM) || process.getStartLink().endsWith(DOT_M_JSON));
   }
 
   public String targetToStartProcess(Process process) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardProcessBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardProcessBean.java
@@ -133,7 +133,7 @@ public class DashboardProcessBean extends AbstractProcessBean implements Seriali
   }
 
   public boolean isCaseMap(DashboardProcess process) {
-    return !Objects.isNull(process) && (process.getStartLink().endsWith(".icm") || process.getStartLink().endsWith(".m.json"));
+    return !Objects.isNull(process) && (process.getStartLink().endsWith(DOT_ICM) || process.getStartLink().endsWith(DOT_M_JSON));
   }
 
   public String getProcessInformationPageUrl(DashboardProcess process) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardProcessBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardProcessBean.java
@@ -133,7 +133,7 @@ public class DashboardProcessBean extends AbstractProcessBean implements Seriali
   }
 
   public boolean isCaseMap(DashboardProcess process) {
-    return !Objects.isNull(process) && process.getStartLink().endsWith(".icm");
+    return !Objects.isNull(process) && (process.getStartLink().endsWith(".icm") || process.getStartLink().endsWith(".m.json"));
   }
 
   public String getProcessInformationPageUrl(DashboardProcess process) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UrlUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UrlUtils.java
@@ -36,7 +36,7 @@ public class UrlUtils {
   public static boolean isIvyUrl(String url) {
     return url == null
         || (Strings.CS.contains(url, ".ivp?")
-            || Strings.CS.endsWithAny(url, ".ivp", ".icm"));
+            || Strings.CS.endsWithAny(url, ".ivp", ".icm", ".m.json"));
   }
 
   public static String buildUrl(String url) {


### PR DESCRIPTION
- The "Convert projects S290 part 2 (#3197)" commit renamed Axon Ivy case map files from .icm → .m.json format.
- All failing tests navigate to case maps using URLs still ending in .icm, which the engine no longer serves — causing either a 404/redirect (producing "element not found" in Pattern B tests) or landing on an unexpected page where the dashboard widget table stays hidden (Pattern A tests).
- All failing tests trace back to one of two .icm URLs: internalSupport/764871e4-cf70-401f-83fb-9e99fa897fc4.icm (used by SideStepTest, ProcessViewerTest, TaskTemplateTest, CaseDetailsTest) /portal-user-examples/70765b37-a3e8-418a-a8d5-c2b3a539408e.icm (used by CaseMapTest)