### PR TITLE
IVYPORTAL-20070 Reduce warnings in Portal part 1 - java files

### DIFF
--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/datamodel/internal/CaseHistoryLazyDataModel.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/datamodel/internal/CaseHistoryLazyDataModel.java
@@ -157,7 +157,6 @@ public class CaseHistoryLazyDataModel extends LazyDataModel<ICase> {
 
   @Override
   public int count(Map<String, FilterMeta> filterBy) {
-    // TODO Auto-generated method stub
     return 0;
   }
 

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/IvyDocumentTransformer.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/IvyDocumentTransformer.java
@@ -16,7 +16,6 @@ public class IvyDocumentTransformer {
     try {
     File  file = new File(document.getPath().asString());
     return IvyDocument.builder()
-              .id(String.valueOf(document.getId()))
               .name(document.getName())
               .path(document.getPath().asString())
               .relativePath(document.getRelativePath().asString())

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/RoleDTO.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/RoleDTO.java
@@ -22,6 +22,7 @@ public class RoleDTO {
     super();
   }
 
+  @SuppressWarnings("removal")
   public RoleDTO(IRole iRole) {
     this.id = iRole.getId();
     this.name = iRole.getName();

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/SecurityMemberDTO.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/SecurityMemberDTO.java
@@ -22,6 +22,7 @@ public class SecurityMemberDTO implements Serializable {
 
   public SecurityMemberDTO() {}
 
+  @SuppressWarnings("removal")
   public SecurityMemberDTO(ISecurityMember securityMember) {
     this.id = securityMember.getId();
     this.securityMemberId = securityMember.getSecurityMemberId();

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/SideStepConfigurationDTO.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/SideStepConfigurationDTO.java
@@ -9,12 +9,9 @@ import org.apache.commons.lang3.StringUtils;
 import com.axonivy.portal.components.util.DisplayNameUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import ch.ivyteam.ivy.workflow.ICase;
-import ch.ivyteam.ivy.workflow.ITask;
-
 /**
  * DTO object contains information about side step configuration.
- * Use this class to configure side step then parse it to JSON and save to custom text field of {@link ITask} or {@link ICase}
+ * Use this class to configure side step then parse it to JSON and save to custom text field of {@link ch.ivyteam.ivy.workflow.ITask} or {@link ch.ivyteam.ivy.workflow.ICase}
  * <pre>
  * <b>processes</b>: list of side step processes for user to select (mandatory). 
  * <b>isParallelSideStep</b>: whether side step task runs parallel with original task (optional).

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/SideStepProcessDTO.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/SideStepProcessDTO.java
@@ -8,8 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 import com.axonivy.portal.components.util.DisplayNameUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import ch.ivyteam.ivy.security.ISecurityContext;
-
 /**
  * DTO object contains information about side step task process.
  * <pre>
@@ -79,7 +77,7 @@ public class SideStepProcessDTO implements Serializable {
 
     /**
      * Sets name of Ivy callable subprocess to define custom list of users or roles which side step can be assigned to.
-     * This is optional. If it's not defined, side step task can assign to all users or roles of {@link ISecurityContext}
+     * This is optional. If it's not defined, side step task can assign to all users or roles of {@link ch.ivyteam.ivy.security.ISecurityContext}
      * @param customSecurityMemberCallable
      * @return builder of {@link SideStepProcessDTO}
      */

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/UserDTO.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/dto/UserDTO.java
@@ -20,6 +20,7 @@ public class UserDTO {
   
   public UserDTO() {}
 
+  @SuppressWarnings("removal")
   public UserDTO(IUser user) {
     this.name = user.getName();
     this.memberName = user.getMemberName();

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/generic/navigation/BaseNavigator.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/generic/navigation/BaseNavigator.java
@@ -15,6 +15,7 @@ import com.axonivy.portal.components.util.ProcessStartUtils;
 import ch.ivyteam.ivy.application.IApplication;
 import ch.ivyteam.ivy.security.exec.Sudo;
 import ch.ivyteam.ivy.workflow.IProcessStart;
+import ch.ivyteam.ivy.workflow.start.IWebStartable;
 import ch.ivyteam.ivy.workflow.StandardProcessType;
 import ch.ivyteam.ivy.workflow.standard.DefaultPagesConfigurator;
 
@@ -72,7 +73,7 @@ public class BaseNavigator {
   }
 
   public static String findAbsoluteUrlByProcessStartFriendlyRequestPath(String friendlyRequestPath) {
-    IProcessStart processStart = ProcessStartUtils.findProcessStartByUserFriendlyRequestPath(friendlyRequestPath);
-    return processStart != null ? processStart.getLink().getAbsolute() : StringUtils.EMPTY;
+    IWebStartable webStartable = ProcessStartUtils.findWebStartableByUserFriendlyRequestPath(friendlyRequestPath);
+    return webStartable != null ? webStartable.getLink().getAbsolute() : StringUtils.EMPTY;
   }
 }

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/jsf/Attrs.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/jsf/Attrs.java
@@ -1,7 +1,5 @@
 package com.axonivy.portal.components.jsf;
 
-import javax.el.ELContext;
-import javax.el.ValueExpression;
 import javax.faces.context.FacesContext;
 
 /**
@@ -23,27 +21,14 @@ import javax.faces.context.FacesContext;
  */
 public class Attrs {
 
-  private final FacesContext facesContext;
-
   private Attrs(FacesContext facesContext) {
     if (facesContext == null) {
       throw new IllegalArgumentException("FacesContext must not be null to use Attrs");
     }
-    this.facesContext = facesContext;
   }
 
   public static Attrs currentContext() {
     return new Attrs(FacesContext.getCurrentInstance());
-  }
-
-  // This method is defined but not in used yet.
-  // Set it `public` and remove the `@SuppressWarning` if you want to publish it.
-  @SuppressWarnings("unused")
-  private void set(String attribute, Object value) {
-    ELContext elContext = facesContext.getELContext();
-    ValueExpression valueExpression = facesContext.getApplication().getExpressionFactory()
-        .createValueExpression(elContext, "#{cc.attrs." + attribute + "}", Object.class);
-    valueExpression.setValue(elContext, value);
   }
 
   public <T> T get(String attribute) {

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/publicapi/ProcessStartAPI.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/publicapi/ProcessStartAPI.java
@@ -12,7 +12,6 @@ import ch.ivyteam.ivy.application.IProcessModelVersion;
 import ch.ivyteam.ivy.application.app.IApplicationRepository;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.security.exec.Sudo;
-import ch.ivyteam.ivy.workflow.IProcessStart;
 import ch.ivyteam.ivy.workflow.IWorkflowProcessModelVersion;
 import ch.ivyteam.ivy.workflow.start.IWebStartable;
 

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/publicapi/ProcessStartAPI.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/publicapi/ProcessStartAPI.java
@@ -36,9 +36,9 @@ public final class ProcessStartAPI {
     return Sudo.get(() -> {
       var apps = IApplicationRepository.of(ISecurityContext.current()).allReleased();
       for (IApplication app : apps) {
-        var processStart = findStartableProcessStartByUserFriendlyRequestPath(friendlyRequestPath, app);
-        if (processStart != null) {
-          return processStart.getLink().getRelative();
+        var webStartable = findWebStartableByUserFriendlyRequestPath(friendlyRequestPath, app);
+        if (webStartable != null) {
+          return webStartable.getLink().getRelative();
         }
       }
       return "";
@@ -53,26 +53,28 @@ public final class ProcessStartAPI {
    * @return start link or empty string
    */
   public static String findRelativeUrlByProcessStartFriendlyRequestPath(String friendlyRequestPath) {
-    IProcessStart processStart = ProcessStartUtils.findProcessStartByUserFriendlyRequestPath(friendlyRequestPath);
-    return processStart != null ? processStart.getLink().getRelative() : StringUtils.EMPTY;
+    IWebStartable webStartable = ProcessStartUtils.findWebStartableByUserFriendlyRequestPath(friendlyRequestPath);
+    return webStartable != null ? webStartable.getLink().getRelative() : StringUtils.EMPTY;
   }
 
-  private static IProcessStart findStartableProcessStartByUserFriendlyRequestPath(String requestPath, IApplication application) {
+  private static IWebStartable findWebStartableByUserFriendlyRequestPath(String requestPath, IApplication application) {
     return application.getProcessModelVersions()
-        .map(p -> getProcessStart(requestPath, p))
+        .map(p -> findWebStartableByPathAndPmv(requestPath, p))
         .filter(Objects::nonNull)
-        .filter(processStart -> isStartableProcessStart(processStart.getLink().getRelative()))
+        .filter(ws -> isStartableProcess(ws.getLink().getRelative()))
         .findFirst()
         .orElse(null);
   }
 
-  private static IProcessStart getProcessStart(String requestPath, IProcessModelVersion processModelVersion) {
-    return IWorkflowProcessModelVersion.of(processModelVersion).findStartElementByUserFriendlyRequestPath(requestPath);
+  private static IWebStartable findWebStartableByPathAndPmv(String requestPath, IProcessModelVersion processModelVersion) {
+    return IWorkflowProcessModelVersion.of(processModelVersion).getAllStartables()
+        .filter(ws -> ws.getId().endsWith(requestPath))
+        .findFirst().orElse(null);
   }
 
-  private static boolean isStartableProcessStart(String processRelativeLink) {
+  private static boolean isStartableProcess(String processRelativeLink) {
     return ProcessService.getInstance().findProcesses().stream()
         .map(IWebStartable::getLink)
-        .filter(webLink -> webLink.getRelative().equals(processRelativeLink)).findFirst().isPresent();
+        .anyMatch(webLink -> webLink.getRelative().equals(processRelativeLink));
   }
 }

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/service/CaseDocumentService.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/service/CaseDocumentService.java
@@ -63,7 +63,7 @@ public class CaseDocumentService {
    */
   public StreamedContent download(IvyDocument document) {
     return DefaultStreamedContent.builder()
-        .stream(() -> documentsOf(iCase).get(Long.valueOf(document.getId())).read().asStream())
+        .stream(() -> documentsOf(iCase).get(document.getUuid()).read().asStream())
         .contentType(document.getContentType())
         .name(document.getName())
         .build();

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/ProcessStartUtils.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/ProcessStartUtils.java
@@ -1,9 +1,7 @@
 package com.axonivy.portal.components.util;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.portal.components.enums.SessionAttribute;
@@ -15,8 +13,8 @@ import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.request.IHttpResponse;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.security.exec.Sudo;
-import ch.ivyteam.ivy.workflow.IProcessStart;
 import ch.ivyteam.ivy.workflow.IWorkflowProcessModelVersion;
+import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 public class ProcessStartUtils {
 
@@ -27,11 +25,19 @@ public class ProcessStartUtils {
     });
   }
 
-  public static IProcessStart findProcessStartByUserFriendlyRequestPath(String requestPath) {
+  public static Long findTaskStartIdByUserFriendlyRequestPath(String requestPath) {
+    return Sudo.get(() -> Ivy.session().getStartableProcessStarts().stream()
+        .filter(ps -> ps.getUserFriendlyRequestPath().endsWith(requestPath))
+        .findFirst()
+        .map(ps -> ps.getTaskStart().getId())
+        .orElse(null));
+  }
+
+  public static IWebStartable findWebStartableByUserFriendlyRequestPath(String requestPath) {
     return Sudo.get(() -> {
-      IProcessStart processStart = findProcessStartByUserFriendlyRequestPathAndPmv(requestPath, Ivy.request().getProcessModelVersion());
-      if (processStart != null) {
-        return processStart;
+      IWebStartable webStartable = findWebStartableByPathAndPmv(requestPath, Ivy.request().getProcessModelVersion());
+      if (webStartable != null) {
+        return webStartable;
       }
 
       List<IApplication> apps = IApplicationRepository.of(ISecurityContext.current()).allReleased();
@@ -39,18 +45,20 @@ public class ProcessStartUtils {
         .flatMap(app -> app.getProcessModelVersions())
         .toList();
       for (var pmv : processModelVersions) {
-        processStart = findProcessStartByUserFriendlyRequestPathAndPmv(requestPath, pmv);
-        if (processStart != null) {
-          return processStart;
+        webStartable = findWebStartableByPathAndPmv(requestPath, pmv);
+        if (webStartable != null) {
+          return webStartable;
         }
       }
-      return processStart;
+      return webStartable;
     });
   }
 
-  private static IProcessStart findProcessStartByUserFriendlyRequestPathAndPmv(String requestPath,
+  private static IWebStartable findWebStartableByPathAndPmv(String requestPath,
       IProcessModelVersion processModelVersion) {
-    return IWorkflowProcessModelVersion.of(processModelVersion).findStartElementByUserFriendlyRequestPath(requestPath);
+    return IWorkflowProcessModelVersion.of(processModelVersion).getAllStartables()
+        .filter(ws -> ws.getId().endsWith(requestPath))
+        .findFirst().orElse(null);
   }
 
   public static void redirect(String uri) throws java.io.IOException {
@@ -72,23 +80,15 @@ public class ProcessStartUtils {
     }
     return StringUtils.EMPTY;
   }
-  
+
   private static String findFriendlyRequestPathContainsKeywordInPMV(String keyword, IProcessModelVersion processModelVersion) {
     if (processModelVersion != null) {
-      List<IProcessStart> processStarts =
-          findProcessStartRequestPathContainsKeywordAndPmv(keyword, processModelVersion);
-      if (CollectionUtils.isNotEmpty(processStarts)) {
-        return processStarts.get(0).getUserFriendlyRequestPath();
-      }
+      return IWorkflowProcessModelVersion.of(processModelVersion).getAllStartables()
+          .filter(ws -> ws.getId().contains(keyword))
+          .findFirst()
+          .map(IWebStartable::getId)
+          .orElse(StringUtils.EMPTY);
     }
     return StringUtils.EMPTY;
-  }
-
-  private static List<IProcessStart> findProcessStartRequestPathContainsKeywordAndPmv(String keyword,
-      IProcessModelVersion processModelVersion) {
-    IWorkflowProcessModelVersion workflowPmv = IWorkflowProcessModelVersion.of(processModelVersion);
-    return workflowPmv.getProcessStarts().stream()
-        .filter(processStart -> processStart.getUserFriendlyRequestPath().contains(keyword))
-        .collect(Collectors.toList());
   }
 }

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/ProcessStartUtils.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/ProcessStartUtils.java
@@ -10,7 +10,6 @@ import com.axonivy.portal.components.enums.SessionAttribute;
 
 import ch.ivyteam.ivy.application.IApplication;
 import ch.ivyteam.ivy.application.IProcessModelVersion;
-import ch.ivyteam.ivy.application.ReleaseState;
 import ch.ivyteam.ivy.application.app.IApplicationRepository;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.request.IHttpResponse;

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/RoleUtils.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/RoleUtils.java
@@ -1,8 +1,9 @@
 package com.axonivy.portal.components.util;
 
-import static java.util.Comparator.comparingLong;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
+
+import java.util.Comparator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -151,7 +152,7 @@ public final class RoleUtils {
   }
 
   /**
-   * Distinct a list of RoleDTO by id then sort by display name.
+   * Distinct a list of RoleDTO by security member ID then sort by display name.
    * 
    * @param roleList original list of roles
    * @return distinct and sorted list of roles
@@ -162,7 +163,7 @@ public final class RoleUtils {
     }
 
     List<RoleDTO> result = roleList.stream()
-        .collect(collectingAndThen(toCollection(() -> new TreeSet<>(comparingLong(RoleDTO::getId))), ArrayList::new));
+        .collect(collectingAndThen(toCollection(() -> new TreeSet<>(Comparator.comparing(RoleDTO::getSecurityMemberId))), ArrayList::new));
 
     result.sort((r1, r2) -> r1.getDisplayName().compareTo(r2.getDisplayName()));
     return result;

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/UserUtils.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/UserUtils.java
@@ -1,10 +1,10 @@
 package com.axonivy.portal.components.util;
 
-import static java.util.Comparator.comparingLong;
-
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
+
+import java.util.Comparator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,7 +77,7 @@ public class UserUtils {
   }
 
   /**
-   * Distinct a list of UserDTO by id then sort by display name.
+   * Distinct a list of UserDTO by security member ID then sort by display name.
    * 
    * @param userList original list of users
    * @return distinct and sorted list of users
@@ -88,7 +88,7 @@ public class UserUtils {
     }
 
     List<UserDTO> result = userList.stream()
-        .collect(collectingAndThen(toCollection(() -> new TreeSet<>(comparingLong(UserDTO::getId))), ArrayList::new));
+        .collect(collectingAndThen(toCollection(() -> new TreeSet<>(Comparator.comparing(UserDTO::getSecurityMemberId))), ArrayList::new));
 
     result.sort((u1, u2) -> u1.getDisplayName().compareTo(u2.getDisplayName()));
     return result;

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/WaitHelper.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/WaitHelper.java
@@ -46,7 +46,7 @@ public final class WaitHelper {
 
   public static void assertTrueWithWait(Supplier<Boolean> supplier) {
     try {
-      wait(WebDriverRunner.getWebDriver()).until(webDriver -> supplier.get());
+      wait(WebDriverRunner.getWebDriver()).until(_ -> supplier.get());
     } catch (Exception e) {
       e.printStackTrace();
       assertTrue(false);

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/LeaveRequestPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/LeaveRequestPage.java
@@ -1,7 +1,5 @@
 package com.axonivy.portal.selenium.page;
 
-import static com.codeborne.selenide.Condition.appear;
-import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TaskWidgetNewDashBoardPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TaskWidgetNewDashBoardPage.java
@@ -1,8 +1,6 @@
 package com.axonivy.portal.selenium.page;
 
 import static com.codeborne.selenide.CollectionCondition.containExactTextsCaseSensitive;
-import static com.codeborne.selenide.CollectionCondition.size;
-import static com.codeborne.selenide.CollectionCondition.sizeGreaterThan;
 import static com.codeborne.selenide.Condition.appear;
 import static com.codeborne.selenide.Condition.disappear;
 import static com.codeborne.selenide.Condition.text;
@@ -25,7 +23,6 @@ import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.ScrollIntoViewOptions;
 import com.codeborne.selenide.SelenideElement;
-import com.codeborne.selenide.WebElementsCondition;
 import com.codeborne.selenide.ScrollIntoViewOptions.Block;
 
 public class TaskWidgetNewDashBoardPage extends TemplatePage {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TaskWidgetPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TaskWidgetPage.java
@@ -663,7 +663,7 @@ public class TaskWidgetPage extends TemplatePage {
 
   public void waitUntilTaskCountDifferentThanZero() {
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((driver) -> getTaskCount().intValue() != 0);
+        .until((_) -> getTaskCount().intValue() != 0);
 
   }
 

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TemplatePage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TemplatePage.java
@@ -390,7 +390,7 @@ public abstract class TemplatePage extends AbstractPage {
   }
 
   protected void refreshAndWaitElement(String cssSelector) {
-    new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT).until((webDriver) -> {
+    new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT).until((_) -> {
       if (($$(cssSelector).isEmpty())) {
         WaitHelper.waitForNavigation(() -> refresh());
         return false;
@@ -488,7 +488,7 @@ public abstract class TemplatePage extends AbstractPage {
 
   public void waitForIFrameScreenshotSizeGreaterThan(long fileSizeInBytes) {
     switchToDefaultContent();
-    new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT).until((driver) -> {
+    new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT).until((_) -> {
       return $("iFrame").getScreenshotAs(OutputType.FILE).length() > fileSizeInBytes;
     });
     switchToIFrameOfTask();

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TopMenuTaskWidgetPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TopMenuTaskWidgetPage.java
@@ -257,12 +257,12 @@ public class TopMenuTaskWidgetPage extends TaskWidgetNewDashBoardPage {
 
   public void waitUntilTaskCountDifferentThanZero() {
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((driver) -> countAllTasks().size() != 0);
+        .until((_) -> countAllTasks().size() != 0);
   }
 
   public void waitUntilTaskFilterReturnResultCount(int count) {
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((driver) -> countAllTasks().size() == count);
+        .until((_) -> countAllTasks().size() == count);
   }
 
   public void isDelegateTypeSelectAvailable() {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/ChatTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/ChatTest.java
@@ -34,8 +34,7 @@ public class ChatTest extends BaseTest {
 
   // Currently still not have any idea how to open two browser with difference session to test chat between multiple
   // user
-  // Tests that still not implement
-  // TODO chatGroupMultiTabs, chatGroupOnTwoInstanceOfBrowser
+  // Tests that still not implement chatGroupMultiTabs, chatGroupOnTwoInstanceOfBrowser
 
   @Test
   public void chatAddGroup() {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/PasswordValidationTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/PasswordValidationTest.java
@@ -60,7 +60,7 @@ public class PasswordValidationTest extends BaseTest {
     accessToPasswordValidation();
     passwordValidationPage.clickOnPasswordValidationToggle();
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((driver) -> passwordValidationPage.isEnableSaveButton());
+        .until((_) -> passwordValidationPage.isEnableSaveButton());
     assertTrue(passwordValidationPage.isEnableSaveButton());
   }
 
@@ -80,10 +80,10 @@ public class PasswordValidationTest extends BaseTest {
     accessToPasswordValidation();
     passwordValidationPage.clickOnPasswordValidationToggle();
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((driver) -> passwordValidationPage.isEnableSaveButton());
+        .until((_) -> passwordValidationPage.isEnableSaveButton());
     passwordValidationPage.clickOnSaveButton();
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((driver) -> !passwordValidationPage.isEnableSaveButton());
+        .until((_) -> !passwordValidationPage.isEnableSaveButton());
   }
 
   private PasswordValidationPage accessToPasswordValidation() {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/ProcessWidgetTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/ProcessWidgetTest.java
@@ -62,9 +62,9 @@ public class ProcessWidgetTest extends BaseTest {
     processWidget.waitPageLoaded();
     assertNotNull(processWidget.getProcess(AGOOGLE_LINK));
     processWidget.startProcess(AGOOGLE_LINK);
-    webDriverWait().until((webDriver) -> newDashboardPage.countBrowserTab() > 1);
+    webDriverWait().until((_) -> newDashboardPage.countBrowserTab() > 1);
     newDashboardPage.switchLastBrowserTab();
-    webDriverWait().until((webDriver) -> newDashboardPage.getPageTitle().length() > 1);
+    webDriverWait().until((_) -> newDashboardPage.getPageTitle().length() > 1);
     assertEquals("Google", newDashboardPage.getPageTitle());
     resetLanguageOfCurrentUser();
   }

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/caze/CaseDetailsTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/caze/CaseDetailsTest.java
@@ -329,7 +329,7 @@ public class CaseDetailsTest extends BaseTest {
     detailsPage.clickRelatedCaseActionButton(0);
     AdditionalCaseDetailsPage caseDetailsPage = detailsPage.openRelatedCaseBusinessDetail(0);
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((webDriver) -> caseDetailsPage.countBrowserTab() > 1);
+        .until((_) -> caseDetailsPage.countBrowserTab() > 1);
     caseDetailsPage.switchLastBrowserTab();
     AdditionalCaseDetailsPage additionalCaseDetailsPage = new AdditionalCaseDetailsPage();
     WaitHelper.assertTrueWithWait(() -> BUSINESS_DETAILS_TITLE.equals(additionalCaseDetailsPage.getPageTitle()));
@@ -416,7 +416,7 @@ public class CaseDetailsTest extends BaseTest {
     int relatedDoneTasks = detailsPage.countRelatedDoneTasks();
     detailsPage.showNoteHistory();
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((webDriver) -> detailsPage.countBrowserTab() > 1);
+        .until((_) -> detailsPage.countBrowserTab() > 1);
     detailsPage.switchLastBrowserTab();
     NoteHistoryPage caseHistoryPage = new NoteHistoryPage();
     assertEquals(relatedDoneTasks, caseHistoryPage.countDoneTasks());
@@ -505,7 +505,7 @@ public class CaseDetailsTest extends BaseTest {
     detailsPage.clickRelatedCaseActionButton(0);
     CaseDetailsPage relatedCaseDetailsPage = detailsPage.openCasesOfCasePageViaDetailsAction(0);
     new WebDriverWait(WebDriverRunner.getWebDriver(), DEFAULT_TIMEOUT)
-        .until((webDriver) -> CASE_DETAILS_TITLE.equals(relatedCaseDetailsPage.getPageTitle()));
+        .until((_) -> CASE_DETAILS_TITLE.equals(relatedCaseDetailsPage.getPageTitle()));
 
     relatedCaseDetailsPage.addNote("The first note of sub-case");
     relatedCaseDetailsPage.waitForPageLoad();

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/chat/ChatService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/chat/ChatService.java
@@ -483,7 +483,7 @@ public class ChatService {
     if (isChatResponseTimeoutConfigured()) {
       Long chatResponseTimeout = Long.parseLong(getChatResponseTimeoutValue());
       response.setTimeout(chatResponseTimeout, TimeUnit.SECONDS);
-      response.setTimeoutHandler(asyncResponse -> {
+      response.setTimeoutHandler(_ -> {
         for (Queue<ResponseInfo> queue : userToResponse.values()) {
           ResponseInfo responseInfo =
               queue.stream().filter(info -> info.getAsyncResponse().equals(response)).findFirst().orElse(null);

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/chat/GroupChat.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/chat/GroupChat.java
@@ -91,6 +91,7 @@ public class GroupChat implements Serializable {
     return this.assignees;
   }
 
+  @SuppressWarnings("removal")
   public void setAssignees(Set<SecurityMemberDTO> assignees) {
     this.assignees = assignees;
     if (CollectionUtils.isNotEmpty(assignees)) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/chat/PortalSessionExtension.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/chat/PortalSessionExtension.java
@@ -17,7 +17,6 @@ import ch.ivyteam.ivy.security.ISessionExtension;
 import ch.ivyteam.ivy.security.exec.Sudo;
 import ch.ivyteam.log.Logger;
 
-@SuppressWarnings("restriction")
 public final class PortalSessionExtension implements ISessionExtension {
   private static PortalSessionExtension instance;
   private IvyAsyncExecutor asyncExecutor;

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ChatRendererBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ChatRendererBean.java
@@ -16,8 +16,7 @@ import ch.ivy.addon.portalkit.enums.GlobalVariable;
 import ch.ivy.addon.portalkit.service.AiProcessService;
 import ch.ivy.addon.portalkit.service.GlobalSettingService;
 import ch.ivyteam.ivy.environment.Ivy;
-import ch.ivyteam.ivy.model.value.WebLink;
-import ch.ivyteam.ivy.workflow.IProcessStart;
+import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 @ManagedBean
 @ViewScoped
@@ -27,7 +26,7 @@ public class ChatRendererBean implements Serializable {
   
   private Boolean isGroupChatRendered;
   private Boolean isPrivateChatRendered;
-  private IProcessStart assistantDashboardProcess;
+  private IWebStartable assistantDashboardProcess;
   
   public boolean getIsChatRendered() {
     return getIsGroupChatRendered() || getIsPrivateChatRendered();
@@ -67,7 +66,7 @@ public class ChatRendererBean implements Serializable {
           .findAssistantDashboardProcess();
     }
     return StringUtils.isNotBlank(Optional.ofNullable(assistantDashboardProcess)
-        .map(IProcessStart::getLinkEmbedded).map(WebLink::getRelative)
+        .map(ws -> ws.getLink().getRelative())
         .orElse(""));
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardDetailModificationBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardDetailModificationBean.java
@@ -16,7 +16,6 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -107,7 +106,7 @@ import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 @ViewScoped
 @ManagedBean
-public class DashboardDetailModificationBean extends DashboardBean implements Serializable, PropertyChangeListener {
+public class DashboardDetailModificationBean extends DashboardBean implements PropertyChangeListener {
 
   private static final long serialVersionUID = -5272278165636659596L;
   private static final String DEFAULT_COMPLEX_USER_FILTER_ID = "widget-configuration-form:new-widget-configuration-component:predefined-filter";
@@ -570,7 +569,7 @@ public class DashboardDetailModificationBean extends DashboardBean implements Se
     }
   }
   
-  public void onReset(@SuppressWarnings("unused") DashboardWidget widget) {
+  public void onReset(DashboardWidget widget) {
     resetUserFilter();
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardModificationBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardModificationBean.java
@@ -1,7 +1,6 @@
 package ch.ivy.addon.portal.generic.bean;
 
 import java.io.ByteArrayInputStream;
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -58,7 +57,7 @@ import ch.ivyteam.ivy.environment.Ivy;
 
 @ViewScoped
 @ManagedBean
-public class DashboardModificationBean extends DashboardBean implements Serializable {
+public class DashboardModificationBean extends DashboardBean {
 
   private static final long serialVersionUID = 1L;
   protected static final String PUBLIC_DASHBOARD_DEFAULT_ICON = "si-network-share";

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardModificationBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardModificationBean.java
@@ -131,7 +131,7 @@ public class DashboardModificationBean extends DashboardBean implements Serializ
     if (CollectionUtils.isNotEmpty(responsibles)) {
       Collection<SecurityMemberDTO> distinctPermissionDTOs = responsibles.stream()
           .collect(Collectors
-              .toMap(SecurityMemberDTO::getMemberName, responsible -> responsible, (responsible1, responsible2) -> responsible1)).values();
+              .toMap(SecurityMemberDTO::getMemberName, responsible -> responsible, (responsible1, _) -> responsible1)).values();
       responsibles.clear();
       responsibles.addAll(distinctPermissionDTOs);
       displayedPermission = responsibles.stream().map(SecurityMemberDTO::getDisplayName).collect(Collectors.joining(", "));
@@ -309,7 +309,7 @@ public class DashboardModificationBean extends DashboardBean implements Serializ
     List<DisplayName> languages = this.selectedDashboard.getTitles();
     return languages.stream()
         .filter(o -> o.getLocale() != null)
-        .collect(Collectors.toMap(o -> o.getLocale().getLanguage(), o -> o, (existing, replacement) -> existing));
+        .collect(Collectors.toMap(o -> o.getLocale().getLanguage(), o -> o, (existing, _) -> existing));
   }
 
   private void initMultipleLanguagesForDashboardName(String currentTitle) {
@@ -401,7 +401,7 @@ public class DashboardModificationBean extends DashboardBean implements Serializ
     all.addAll(DashboardUtils.getPublicDashboards());
     all.addAll(DashboardUtils.getPrivateDashboards());
     return all.stream().filter(d -> d.getId() != null)
-        .collect(Collectors.toMap(Dashboard::getId, d -> d, (a, b) -> a));
+        .collect(Collectors.toMap(Dashboard::getId, d -> d, (a, _) -> a));
   }
 
   private void prepareDashboardForExport(Dashboard dashboard) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardTemplateSelectionBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardTemplateSelectionBean.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portal.generic.bean;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 
 import javax.faces.bean.ManagedBean;
@@ -15,7 +14,7 @@ import ch.ivy.addon.portalkit.util.DashboardWidgetUtils;
 
 @ViewScoped
 @ManagedBean
-public class DashboardTemplateSelectionBean extends DashboardModificationBean implements Serializable {
+public class DashboardTemplateSelectionBean extends DashboardModificationBean {
 
   private static final long serialVersionUID = 6975567087140152855L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/IFrameTaskTemplateBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/IFrameTaskTemplateBean.java
@@ -1,7 +1,6 @@
 package ch.ivy.addon.portal.generic.bean;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +36,7 @@ import ch.ivyteam.ivy.workflow.TaskState;
 
 @ManagedBean(name = "iFrameTaskTemplateBean")
 @ViewScoped
-public class IFrameTaskTemplateBean extends AbstractTaskTemplateBean implements Serializable {
+public class IFrameTaskTemplateBean extends AbstractTaskTemplateBean {
 
   private static final long serialVersionUID = 1L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/NavigationDashboardWidgetConfigurationBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/NavigationDashboardWidgetConfigurationBean.java
@@ -1,7 +1,5 @@
 package ch.ivy.addon.portal.generic.bean;
 
-import java.io.Serializable;
-
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -13,7 +11,7 @@ import com.axonivy.portal.util.ImageUploadUtils;
 
 @ViewScoped
 @ManagedBean
-public class NavigationDashboardWidgetConfigurationBean extends NavigationDashboardWidgetBean implements Serializable, IMultiLanguage {
+public class NavigationDashboardWidgetConfigurationBean extends NavigationDashboardWidgetBean implements IMultiLanguage {
 
   private static final long serialVersionUID = 1L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/TaskTemplateBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/TaskTemplateBean.java
@@ -1,12 +1,10 @@
 package ch.ivy.addon.portal.generic.bean;
 
-import java.io.Serializable;
-
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
 @ManagedBean
 @ViewScoped
-public class TaskTemplateBean extends AbstractTaskTemplateBean implements Serializable{
+public class TaskTemplateBean extends AbstractTaskTemplateBean {
   private static final long serialVersionUID = 1L;
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/UserProfileBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/UserProfileBean.java
@@ -67,7 +67,7 @@ public class UserProfileBean implements Serializable {
 
   private void resetChannel(IvyNotificationChannelDTO channel) {
     channel.getSubscriptions().forEach(
-        (event, subscription) -> subscription.setState(IvyNotificationChannelSubcriptionDTO.State.USE_DEFAULT));
+        (_, subscription) -> subscription.setState(IvyNotificationChannelSubcriptionDTO.State.USE_DEFAULT));
     saveChannel(channel);
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/navigation/PortalNavigator.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/navigation/PortalNavigator.java
@@ -22,10 +22,9 @@ import ch.ivy.addon.portalkit.enums.SessionAttribute;
 import ch.ivy.addon.portalkit.service.AiProcessService;
 import ch.ivy.addon.portalkit.util.RequestUtils;
 import ch.ivyteam.ivy.environment.Ivy;
-import ch.ivyteam.ivy.model.value.WebLink;
 import ch.ivyteam.ivy.request.IHttpRequest;
-import ch.ivyteam.ivy.workflow.IProcessStart;
 import ch.ivyteam.ivy.workflow.StandardProcessType;
+import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 public final class PortalNavigator extends BaseNavigator{
   private static final String PORTAL_DASHBOARD = "Start Processes/PortalStart/DefaultDashboardPage.ivp";
@@ -269,10 +268,8 @@ public final class PortalNavigator extends BaseNavigator{
   }
 
   public static String buildAssistantDashboardUrl() {
-    IProcessStart process = AiProcessService.getInstance()
-        .findAssistantDashboardProcess();
-    return Optional.ofNullable(process).map(IProcessStart::getLinkEmbedded)
-        .map(WebLink::getRelative).orElse("");
+    IWebStartable process = AiProcessService.getInstance().findAssistantDashboardProcess();
+    return Optional.ofNullable(process).map(ws -> ws.getLink().getRelative()).orElse("");
   }
   
   public static String buildCustomStatisticUrl(Map<String, String> param) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/CaseActionBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/CaseActionBean.java
@@ -44,7 +44,7 @@ public class CaseActionBean implements Serializable {
     return PortalProcessViewerUtils.getStartProcessViewerPageUri(selectedCase);
   }
 
-  public boolean showProcessOverviewLink(@SuppressWarnings("unused") ICase iCaze) {
+  public boolean showProcessOverviewLink(ICase iCaze) {
     return GlobalSettingService.getInstance().findGlobalSettingValueAsBoolean(GlobalVariable.SHOW_PROCESS_INFORMATION);
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/CaseDetailsBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/CaseDetailsBean.java
@@ -1,7 +1,6 @@
 package ch.ivy.addon.portalkit.bean;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -48,7 +47,7 @@ import ch.ivyteam.ivy.workflow.query.CaseQuery;
 
 @ManagedBean
 @ViewScoped
-public class CaseDetailsBean extends AbstractConfigurableContentBean<CaseDetails> implements Serializable {
+public class CaseDetailsBean extends AbstractConfigurableContentBean<CaseDetails> {
 
   private static final long serialVersionUID = 1023540096176033250L;
   private static final String OPEN_CASES_LIST = "Start Processes/PortalStart/CaseListPage.ivp";

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/CombinedDashboardProcessBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/CombinedDashboardProcessBean.java
@@ -74,6 +74,7 @@ public class CombinedDashboardProcessBean
     newWidget.setName(StringUtils.EMPTY);
   }
 
+  @SuppressWarnings("removal")
   public void updateProcessStartId() {
     if (CollectionUtils.isEmpty(startableProcessStarts)) {
       initStartableProcessStarts();

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardProcessBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardProcessBean.java
@@ -3,7 +3,6 @@ package ch.ivy.addon.portalkit.bean;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +33,7 @@ import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 @ManagedBean
 @ViewScoped
-public class DashboardProcessBean extends AbstractProcessBean implements Serializable {
+public class DashboardProcessBean extends AbstractProcessBean {
 
   private static final long serialVersionUID = -6664090186198762432L;
   private List<ProcessWidgetMode> displayModes;
@@ -75,7 +74,6 @@ public class DashboardProcessBean extends AbstractProcessBean implements Seriali
   protected List<Process> findProcesses() {
     List<IWebStartable> processes = ProcessService.getInstance().findProcesses();
     List<Process> defaultPortalProcesses = new ArrayList<>();
-    // TODO fix static ProcessService#ivyProcessResultDTO, maybe cause error when Jmeter 10 user NavigateToGlobalSearch
     if (CollectionUtils.isNotEmpty(processes)) {
       processes.forEach(process -> defaultPortalProcesses.add(new DashboardProcess(process)));
     }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardWelcomeWidgetConfigurationBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/DashboardWelcomeWidgetConfigurationBean.java
@@ -2,7 +2,6 @@ package ch.ivy.addon.portalkit.bean;
 
 import static com.axonivy.portal.util.WelcomeWidgetUtils.DEFAULT_LOCALE_AND_DOT;
 
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +38,7 @@ import ch.ivyteam.ivy.environment.Ivy;
 
 @ViewScoped
 @ManagedBean
-public class DashboardWelcomeWidgetConfigurationBean extends DashboardWelcomeWidgetBean implements Serializable, IMultiLanguage  {
+public class DashboardWelcomeWidgetConfigurationBean extends DashboardWelcomeWidgetBean implements IMultiLanguage  {
 
   private static final long serialVersionUID = 597266282990903281L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ExternalLinkBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ExternalLinkBean.java
@@ -57,6 +57,7 @@ public class ExternalLinkBean implements Serializable, IMultiLanguage {
     PrimeFaces.current().resetInputs(clientId + ":add-external-link-form");
   }
 
+  @SuppressWarnings("removal")
   public ExternalLink saveNewExternalLink() {
     IUser sessionUser = Ivy.session().getSessionUser();
     externalLink.setCreatorId(sessionUser.getId());

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/PortalPermissionInitBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/PortalPermissionInitBean.java
@@ -51,7 +51,7 @@ public class PortalPermissionInitBean extends AbstractProcessStartEventBean {
 
   private void initPermissions() {
     recreateAndGrantPermissions();
-    if (EngineMode.isAnyOf(EngineMode.DEMO, EngineMode.DESIGNER_EMBEDDED) && isIvySecuritySystem()) {
+    if (EngineMode.is(EngineMode.DEMO) && isIvySecuritySystem()) {
       PortalSecurity.INSTANCE.assignPermissionsToDefaultUsers();
     }
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ProcessWidgetBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ProcessWidgetBean.java
@@ -135,7 +135,7 @@ public class ProcessWidgetBean extends AbstractProcessBean implements Serializab
     List<Process> processesBySpecialCharacterGroup = processesByAlphabet.remove(SPECIAL_CHARACTER_KEY);
     Collator collator = Collator.getInstance(Locale.GERMAN);
     processesByAlphabet = processesByAlphabet.entrySet().stream().sorted(Map.Entry.comparingByKey(collator::compare))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e2, LinkedHashMap::new));
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (_, e2) -> e2, LinkedHashMap::new));
     if (CollectionUtils.isNotEmpty(processesBySpecialCharacterGroup)) {
       processesByAlphabet.put(SPECIAL_CHARACTER_KEY, processesBySpecialCharacterGroup);
     }
@@ -298,7 +298,8 @@ public class ProcessWidgetBean extends AbstractProcessBean implements Serializab
       return;
     }
     removeTempExternalLinkImage();
-    ImageUploadResult imageInfo = ImageUploadUtils.handleImageUpload(event, ImageUploadUtils.EXTERNAL_LINK_IMAGE_DIRECTORY);    if (imageInfo.isInvalid()) {
+    ImageUploadResult imageInfo = ImageUploadUtils.handleImageUpload(event, ImageUploadUtils.EXTERNAL_LINK_IMAGE_DIRECTORY);
+    if (imageInfo.isInvalid()) {
       FacesMessage message = new FacesMessage(FacesMessage.SEVERITY_ERROR,
           Ivy.cms().co("/ch.ivy.addon.portalkit.ui.jsf/documentFiles/fileContainScript"), null);
       FacesContext.getCurrentInstance().addMessage("edit-external-link-error-message", message);

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ProcessWidgetBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ProcessWidgetBean.java
@@ -2,7 +2,6 @@ package ch.ivy.addon.portalkit.bean;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
-import java.io.Serializable;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,7 +61,7 @@ import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 @ManagedBean
 @ViewScoped
-public class ProcessWidgetBean extends AbstractProcessBean implements Serializable, IMultiLanguage {
+public class ProcessWidgetBean extends AbstractProcessBean implements IMultiLanguage {
 
   private static final long serialVersionUID = -5889375917550618261L;
   private static final String SPECIAL_CHARACTER_KEY = "SPECIAL_CHARACTER";

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/RoleManagementBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/RoleManagementBean.java
@@ -204,7 +204,7 @@ public class RoleManagementBean implements Serializable {
           .stream()
           .filter(role -> role.getSecurityMemberId().equals(existedRole.getSecurityMemberId()))
           .findFirst()
-          .ifPresentOrElse((user) -> {
+          .ifPresentOrElse((_) -> {
             if (isRemove) {
               foundUser.removeRole(existedRole);
             }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/TaskDetailsBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/TaskDetailsBean.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.bean;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.EnumSet;
@@ -33,7 +32,7 @@ import ch.ivyteam.ivy.workflow.TaskState;
 
 @ViewScoped
 @ManagedBean
-public class TaskDetailsBean extends AbstractConfigurableContentBean<TaskDetails> implements Serializable {
+public class TaskDetailsBean extends AbstractConfigurableContentBean<TaskDetails> {
 
   private static final long serialVersionUID = 8566646437739271552L;
   private static final String RESET_TASK_FRIENDLY_REQUEST_PATH = "Start Processes/PortaStart/ResetTask.ivp";

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/TaskWidgetBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/TaskWidgetBean.java
@@ -53,7 +53,7 @@ public class TaskWidgetBean implements Serializable {
         .equals(BehaviourWhenClickingOnLineInTaskList.RUN_TASK.name());
   }
   
-  public void preRender(@SuppressWarnings("unused") TaskLazyDataModel dataModel) {}
+  public void preRender(TaskLazyDataModel dataModel) {}
 
   public Long getExpandedTaskId() {
     return expandedTaskId;

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ThirdPartyApplicationBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ThirdPartyApplicationBean.java
@@ -94,7 +94,7 @@ public class ThirdPartyApplicationBean implements Serializable, IMultiLanguage {
     if (CollectionUtils.isNotEmpty(responsibles)) {
       Collection<SecurityMemberDTO> distinctPermissionDTOs =
           responsibles.stream().collect(Collectors.toMap(SecurityMemberDTO::getMemberName, responsible -> responsible,
-              (responsible1, responsible2) -> responsible1)).values();
+              (responsible1, _) -> responsible1)).values();
       responsibles.clear();
       responsibles.addAll(distinctPermissionDTOs);
       displayedPermission =

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bo/ExpiryStatistic.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bo/ExpiryStatistic.java
@@ -1,18 +1,24 @@
 package ch.ivy.addon.portalkit.bo;
 
-import java.util.Date;
-import java.util.Map;
-
 public class ExpiryStatistic {
 
-  private Map<Date, Long> numberOfTasksByExpiryTime;
+  private long numberOfTasksExpiredToday;
+  private long numberOfTasksExpiredThisWeek;
 
-  public Map<Date, Long> getNumberOfTasksByExpiryTime() {
-    return numberOfTasksByExpiryTime;
+  public long getNumberOfTasksExpiredToday() {
+    return numberOfTasksExpiredToday;
   }
 
-  public void setNumberOfTasksByExpiryTime(Map<Date, Long> numberOfTasksByExpiryTime) {
-    this.numberOfTasksByExpiryTime = numberOfTasksByExpiryTime;
+  public void setNumberOfTasksExpiredToday(long numberOfTasksExpiredToday) {
+    this.numberOfTasksExpiredToday = numberOfTasksExpiredToday;
   }
-  
+
+  public long getNumberOfTasksExpiredThisWeek() {
+    return numberOfTasksExpiredThisWeek;
+  }
+
+  public void setNumberOfTasksExpiredThisWeek(long numberOfTasksExpiredThisWeek) {
+    this.numberOfTasksExpiredThisWeek = numberOfTasksExpiredThisWeek;
+  }
+
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/ExternalLink.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/ExternalLink.java
@@ -85,6 +85,7 @@ public class ExternalLink extends AbstractConfiguration {
   }
 
   @JsonIgnore
+  @SuppressWarnings("removal")
   public boolean isAbleToEdit() {
     return (this.creatorId == null || PermissionUtils.isSessionUserHasAdminRole()) ? true : this.creatorId == Ivy.session().getSessionUser().getId();
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/CaseLazyDataModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/CaseLazyDataModel.java
@@ -205,6 +205,7 @@ public class CaseLazyDataModel extends LazyDataModel<ICase> {
     }
   }
 
+  @SuppressWarnings("removal")
   protected void initSelectedColumns() {
     CaseColumnsConfigurationService service = CaseColumnsConfigurationService.getInstance();
     Long userId = Optional.ofNullable(Ivy.session().getSessionUser()).map(IUser::getId).orElse(null);
@@ -223,6 +224,7 @@ public class CaseLazyDataModel extends LazyDataModel<ICase> {
     setDisableSelectionCheckboxes(isAutoHideColumns);
   }
   
+  @SuppressWarnings("removal")
   public void saveColumnsConfiguration() {
     // avoid duplicating
     for (String requiredColumn : portalRequiredColumns) {
@@ -246,6 +248,7 @@ public class CaseLazyDataModel extends LazyDataModel<ICase> {
     initSelectedColumns();
   }
 
+  @SuppressWarnings("removal")
   private CaseColumnsConfiguration createNewCaseColumnsConfigurationData() {
     CaseColumnsConfiguration caseColumnsConfiguration = new CaseColumnsConfiguration();
     caseColumnsConfiguration.setProcessModelId(Ivy.request().getProcessModelVersion().getId());

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/DashboardProcessCaseLazyDataModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/DashboardProcessCaseLazyDataModel.java
@@ -123,7 +123,6 @@ public class DashboardProcessCaseLazyDataModel extends LazyDataModel<ICase> {
 
   @Override
   public int count(Map<String, FilterMeta> filterBy) {
-    // TODO Auto-generated method stub
     return 0;
   }
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/DashboardProcessTaskLazyDataModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/DashboardProcessTaskLazyDataModel.java
@@ -123,7 +123,6 @@ public class DashboardProcessTaskLazyDataModel extends LazyDataModel<ITask> {
 
   @Override
   public int count(Map<String, FilterMeta> filterBy) {
-    // TODO Auto-generated method stub
     return 0;
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/TaskLazyDataModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/TaskLazyDataModel.java
@@ -259,6 +259,7 @@ public class TaskLazyDataModel extends LazyDataModel<ITask> {
     }
   }
 
+  @SuppressWarnings("removal")
   protected void initSelectedColumns() {
     TaskColumnsConfigurationService service = TaskColumnsConfigurationService.getInstance();
     Long userId = Optional.ofNullable(Ivy.session().getSessionUser()).map(IUser::getId).orElse(null);
@@ -352,6 +353,7 @@ public class TaskLazyDataModel extends LazyDataModel<ITask> {
     return Ivy.cms().co("/ch.ivy.addon.portalkit.ui.jsf/taskList/defaultColumns/" + column);
   }
 
+  @SuppressWarnings("removal")
   public void saveColumnsConfiguration() {
     // avoid duplicating
     for (String requiredColumn : portalRequiredColumns) {
@@ -374,6 +376,7 @@ public class TaskLazyDataModel extends LazyDataModel<ITask> {
     initSelectedColumns();
   }
 
+  @SuppressWarnings("removal")
   private TaskColumnsConfiguration createNewTaskColumnsConfigurationData() {
     TaskColumnsConfiguration taskColumnsConfiguration = new TaskColumnsConfiguration();
     taskColumnsConfiguration.setProcessModelId(Ivy.request().getProcessModelVersion().getId());

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/casedetails/CaseDetails.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/casedetails/CaseDetails.java
@@ -1,7 +1,5 @@
 package ch.ivy.addon.portalkit.dto.casedetails;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -10,7 +8,7 @@ import ch.ivy.addon.portalkit.dto.AbstractWidgetFilter;
 import ch.ivy.addon.portalkit.dto.AbstractConfigurableContent;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class CaseDetails extends AbstractConfigurableContent implements Serializable {
+public class CaseDetails extends AbstractConfigurableContent {
 
   private static final long serialVersionUID = -8424800742022240884L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
@@ -2,8 +2,6 @@ package ch.ivy.addon.portalkit.dto.dashboard;
 
 import static ch.ivy.addon.portalkit.constant.DashboardConfigurationPrefix.CMS;
 
-import java.io.Serializable;
-
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.validator.ValidatorException;
@@ -22,7 +20,7 @@ import ch.ivyteam.ivy.workflow.custom.field.ICustomFields;
 @JsonIgnoreProperties({"format", "filterType", "filterListOptions", "dateFilterFrom", "dateFilterTo", "userFilter",
     "userFilterList", "userFilterFrom", "userFilterTo", "userDateFilterFrom", "userDateFilterTo",
     "userFilterListOptions"})
-public class ColumnModel extends AbstractColumn implements Serializable {
+public class ColumnModel extends AbstractColumn {
 
   private static final long serialVersionUID = -4315469062114036720L;
 
@@ -35,7 +33,6 @@ public class ColumnModel extends AbstractColumn implements Serializable {
   }
 
   @JsonIgnore
-  @SuppressWarnings("unused")
   public void validate(FacesContext context, UIComponent component, Object value) throws ValidatorException {}
   
   @JsonIgnore

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/CombinedProcessDashboardWidget.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/CombinedProcessDashboardWidget.java
@@ -52,6 +52,7 @@ public class CombinedProcessDashboardWidget extends SingleProcessDashboardWidget
   }
 
   @Override
+  @SuppressWarnings("removal")
   public void setProcess(DashboardProcess process) {
     super.setProcess(process);
     if (getProcess() != null) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/FilterColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/FilterColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -13,7 +12,7 @@ import ch.ivy.addon.portalkit.enums.DashboardColumnType;
 @JsonIgnoreProperties({"header", "styleClass", "fieldStyleClass", "style", "fieldStyle", "visible", "sortable",
     "sorted", "sortDescending", "dateFilterFrom", "dateFilterTo", "userDateFilterFrom", "userDateFilterTo",
     "filterList", "filterListOptions", "userFilterListOptions", "filterType" })
-public class FilterColumnModel extends AbstractColumn implements Serializable {
+public class FilterColumnModel extends AbstractColumn {
 
   private static final long serialVersionUID = -6624895834973797177L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/WelcomeDashboardWidget.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/WelcomeDashboardWidget.java
@@ -200,7 +200,6 @@ public class WelcomeDashboardWidget extends DashboardWidget {
 
   @Override
   public void cancelUserFilter() {
-    // TODO Auto-generated method stub
     
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/ActionsColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/ActionsColumnModel.java
@@ -1,12 +1,10 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardColumnFormat;
 import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class ActionsColumnModel extends CaseColumnModel implements Serializable {
+public class ActionsColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = 5096010835140006329L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/ApplicationColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/ApplicationColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -16,7 +15,7 @@ import ch.ivyteam.ivy.application.app.IApplicationRepository;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class ApplicationColumnModel extends CaseColumnModel implements Serializable {
+public class ApplicationColumnModel extends CaseColumnModel {
   private static final long serialVersionUID = 6708953330031478257L;
 
   @Override
@@ -57,9 +56,9 @@ public class ApplicationColumnModel extends CaseColumnModel implements Serializa
     return false;
   }
   
-  public void updateApplications(@SuppressWarnings("unused") CaseDashboardWidget widget) {
+  public void updateApplications(CaseDashboardWidget widget) {
   }
-  public void initializeApplications(@SuppressWarnings("unused") CaseDashboardWidget widget) {
+  public void initializeApplications(CaseDashboardWidget widget) {
   }
   
   @Override

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CreatedDateColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CreatedDateColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -18,7 +17,7 @@ import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class CreatedDateColumnModel extends CaseColumnModel implements Serializable {
+public class CreatedDateColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = 4220718522071199773L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CreatorColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CreatorColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,7 +21,7 @@ import ch.ivy.addon.portalkit.util.SecurityMemberUtils;
 import ch.ivyteam.ivy.security.ISecurityMember;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class CreatorColumnModel extends CaseColumnModel implements Serializable {
+public class CreatorColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = -7953754221117810034L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/DescriptionColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/DescriptionColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class DescriptionColumnModel extends CaseColumnModel implements Serializable {
+public class DescriptionColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = 1111740263997339274L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/FinishedDateColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/FinishedDateColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -18,7 +17,7 @@ import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class FinishedDateColumnModel  extends CaseColumnModel implements Serializable {
+public class FinishedDateColumnModel  extends CaseColumnModel {
 
   private static final long serialVersionUID = -1044297302783214986L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/IdColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/IdColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class IdColumnModel extends CaseColumnModel implements Serializable {
+public class IdColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = -8721107805389913589L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/NameColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/NameColumnModel.java
@@ -1,12 +1,10 @@
 
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class NameColumnModel extends CaseColumnModel implements Serializable {
+public class NameColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = -8593323636310504629L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/OwnerColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/OwnerColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,7 +19,7 @@ import ch.ivy.addon.portalkit.util.SecurityMemberDisplayNameUtils;
 import ch.ivy.addon.portalkit.util.SecurityMemberUtils;
 import ch.ivyteam.ivy.workflow.ICase;
 
-public class OwnerColumnModel extends CaseColumnModel implements Serializable {
+public class OwnerColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = -2458647281596281704L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/PinColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/PinColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivy.addon.portalkit.service.GlobalSettingService;
 
-public class PinColumnModel extends CaseColumnModel implements Serializable {
+public class PinColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = -2024416411665418820L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/StateColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/StateColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.casecolumn;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,7 +14,7 @@ import ch.ivy.addon.portalkit.util.CaseUtils;
 import ch.ivyteam.ivy.workflow.ICase;
 import ch.ivyteam.ivy.workflow.caze.CaseBusinessState;
 
-public class StateColumnModel extends CaseColumnModel implements Serializable {
+public class StateColumnModel extends CaseColumnModel {
 
   private static final long serialVersionUID = 654113365187067735L;
   

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/ApplicationColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/ApplicationColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.process;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +23,7 @@ import ch.ivyteam.ivy.application.IApplication;
 import ch.ivyteam.ivy.application.app.IApplicationRepository;
 import ch.ivyteam.ivy.security.ISecurityContext;
 
-public class ApplicationColumnModel extends ProcessColumnModel implements Serializable {
+public class ApplicationColumnModel extends ProcessColumnModel {
   private static final long serialVersionUID = -4196645833691283486L;
 
   @Override

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/CategoryColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/CategoryColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.process;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -21,7 +20,7 @@ import ch.ivy.addon.portalkit.util.DashboardWidgetUtils;
 import ch.ivy.addon.portalkit.util.ProcessTreeUtils;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class CategoryColumnModel extends ProcessColumnModel implements Serializable {
+public class CategoryColumnModel extends ProcessColumnModel {
 
   private static final long serialVersionUID = -5311971648747993138L;
   @JsonIgnore

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/DescriptionColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/DescriptionColumnModel.java
@@ -1,13 +1,11 @@
 package ch.ivy.addon.portalkit.dto.dashboard.process;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import ch.ivy.addon.portalkit.enums.DashboardStandardProcessColumn;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class DescriptionColumnModel extends ProcessColumnModel implements Serializable {
+public class DescriptionColumnModel extends ProcessColumnModel {
 
   private static final long serialVersionUID = -327372992675183938L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/NameColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/NameColumnModel.java
@@ -1,13 +1,11 @@
 package ch.ivy.addon.portalkit.dto.dashboard.process;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import ch.ivy.addon.portalkit.enums.DashboardStandardProcessColumn;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class NameColumnModel extends ProcessColumnModel implements Serializable {
+public class NameColumnModel extends ProcessColumnModel {
 
   private static final long serialVersionUID = 8951771185949809098L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/ProcessColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/ProcessColumnModel.java
@@ -1,13 +1,11 @@
 package ch.ivy.addon.portalkit.dto.dashboard.process;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class ProcessColumnModel extends ColumnModel implements Serializable {
+public class ProcessColumnModel extends ColumnModel {
 
   private static final long serialVersionUID = 6064393561101193033L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/TypeColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/process/TypeColumnModel.java
@@ -2,7 +2,6 @@ package ch.ivy.addon.portalkit.dto.dashboard.process;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,7 +18,7 @@ import ch.ivy.addon.portalkit.enums.ProcessType;
 import ch.ivyteam.ivy.environment.Ivy;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class TypeColumnModel extends ProcessColumnModel implements Serializable {
+public class TypeColumnModel extends ProcessColumnModel {
 
   private static final long serialVersionUID = -8859506518292689813L;
   @JsonIgnore

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ActionsColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ActionsColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardColumnFormat;
 import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 
-public class ActionsColumnModel extends TaskColumnModel implements Serializable {
+public class ActionsColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ApplicationColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ApplicationColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -16,7 +15,7 @@ import ch.ivyteam.ivy.application.app.IApplicationRepository;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.workflow.ITask;
 
-public class ApplicationColumnModel extends TaskColumnModel implements Serializable {
+public class ApplicationColumnModel extends TaskColumnModel {
   private static final long serialVersionUID = 8918150285605338212L;
 
   @Override
@@ -62,9 +61,9 @@ public class ApplicationColumnModel extends TaskColumnModel implements Serializa
     return false;
   }
 
-  public void updateApplications(@SuppressWarnings("unused") TaskDashboardWidget  widget) {
+  public void updateApplications(TaskDashboardWidget widget) {
   }
-  public void initializeApplications(@SuppressWarnings("unused") TaskDashboardWidget widget) {
+  public void initializeApplications(TaskDashboardWidget widget) {
   }
   
   @Override

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/CreatedDateColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/CreatedDateColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -18,7 +17,7 @@ import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.workflow.ITask;
 
-public class CreatedDateColumnModel extends TaskColumnModel implements Serializable {
+public class CreatedDateColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/DescriptionColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/DescriptionColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 import ch.ivyteam.ivy.workflow.ITask;
 
-public class DescriptionColumnModel extends TaskColumnModel implements Serializable {
+public class DescriptionColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ExpiryDateColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ExpiryDateColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -18,7 +17,7 @@ import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.workflow.ITask;
 
-public class ExpiryDateColumnModel extends TaskColumnModel implements Serializable {
+public class ExpiryDateColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/IdColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/IdColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 import ch.ivyteam.ivy.workflow.ITask;
 
-public class IdColumnModel extends TaskColumnModel implements Serializable {
+public class IdColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/NameColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/NameColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 import ch.ivyteam.ivy.workflow.ITask;
 
-public class NameColumnModel extends TaskColumnModel implements Serializable {
+public class NameColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/PinColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/PinColumnModel.java
@@ -1,11 +1,9 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 import ch.ivy.addon.portalkit.service.GlobalSettingService;
 
-public class PinColumnModel extends TaskColumnModel implements Serializable {
+public class PinColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -7132266991495711489L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/PriorityColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/PriorityColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,7 +13,7 @@ import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 import ch.ivyteam.ivy.workflow.ITask;
 import ch.ivyteam.ivy.workflow.WorkflowPriority;
 
-public class PriorityColumnModel extends TaskColumnModel implements Serializable {
+public class PriorityColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ResponsibleColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/ResponsibleColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,7 +20,7 @@ import ch.ivy.addon.portalkit.util.SecurityMemberUtils;
 import ch.ivyteam.ivy.security.ISecurityMember;
 import ch.ivyteam.ivy.workflow.ITask;
 
-public class ResponsibleColumnModel extends TaskColumnModel implements Serializable {
+public class ResponsibleColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/StartColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/StartColumnModel.java
@@ -1,10 +1,8 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
-
 import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 
-public class StartColumnModel extends TaskColumnModel implements Serializable {
+public class StartColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/StateColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/StateColumnModel.java
@@ -1,6 +1,5 @@
 package ch.ivy.addon.portalkit.dto.dashboard.taskcolumn;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,7 +14,7 @@ import ch.ivy.addon.portalkit.util.TaskUtils;
 import ch.ivyteam.ivy.workflow.ITask;
 import ch.ivyteam.ivy.workflow.task.TaskBusinessState;
 
-public class StateColumnModel extends TaskColumnModel implements Serializable {
+public class StateColumnModel extends TaskColumnModel {
 
   private static final long serialVersionUID = -4315469062114036720L;
   private static final String TASK_BUSINESS_STATE_CMS_PATH = "/ch.ivy.addon.portalkit.ui.jsf/taskBusinessState/";

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/taskdetails/TaskDetails.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/taskdetails/TaskDetails.java
@@ -1,7 +1,5 @@
 package ch.ivy.addon.portalkit.dto.taskdetails;
 
-import java.io.Serializable;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -10,7 +8,7 @@ import ch.ivy.addon.portalkit.dto.AbstractWidgetFilter;
 import ch.ivy.addon.portalkit.dto.AbstractConfigurableContent;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class TaskDetails extends AbstractConfigurableContent implements Serializable {
+public class TaskDetails extends AbstractConfigurableContent {
 
   private static final long serialVersionUID = -8424800742022240884L;
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/exporter/Exporter.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/exporter/Exporter.java
@@ -21,8 +21,6 @@ import org.primefaces.model.StreamedContent;
 
 import ch.ivy.addon.portalkit.bo.ExcelExportSheet;
 import ch.ivy.addon.portalkit.util.ExcelExport;
-import ch.ivyteam.ivy.workflow.ICase;
-import ch.ivyteam.ivy.workflow.ITask;
 
 /**
  * Base class for export
@@ -74,7 +72,7 @@ public abstract class Exporter {
 
   /**
    * Create stream content {@link StreamedContent} to export
-   * @param <T> data type {@link ITask} or {@link ICase}
+   * @param <T> data type {@link ch.ivyteam.ivy.workflow.ITask} or {@link ch.ivyteam.ivy.workflow.ICase}
    * @param data list of tasks or cases to export
    * @return stream content
    * @throws IOException

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/mapper/SecurityMemberDTOMapper.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/mapper/SecurityMemberDTOMapper.java
@@ -13,6 +13,7 @@ import com.axonivy.portal.components.dto.SecurityMemberDTO;
 
 public class SecurityMemberDTOMapper {
   
+  @SuppressWarnings("removal")
   public static SecurityMemberDTO mapFromUserDTO(UserDTO userDTO) {
     SecurityMemberDTO result = new SecurityMemberDTO();
     
@@ -28,6 +29,7 @@ public class SecurityMemberDTOMapper {
     return result;
   }
   
+  @SuppressWarnings("removal")
   public static SecurityMemberDTO mapFromRoleDTO(RoleDTO roleDTO) {
     SecurityMemberDTO result = new SecurityMemberDTO();
     

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/DashboardTaskSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/DashboardTaskSearchCriteria.java
@@ -211,7 +211,6 @@ public class DashboardTaskSearchCriteria {
 
     private TaskQuery query;
     private OrderByColumnQuery order;
-    @SuppressWarnings("unused")
     private boolean sortStandardColumn;
 
     public TaskSortingQueryAppender(TaskQuery query) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
@@ -279,7 +279,7 @@ public class TaskSearchCriteria {
       }
     }
     
-    private void appendSortByCategoryIfSet(@SuppressWarnings("unused") TaskSearchCriteria criteria) {
+    private void appendSortByCategoryIfSet(TaskSearchCriteria criteria) {
 //      if (TaskSortField.CATEGORY.toString().equalsIgnoreCase(criteria.getSortField())) {
 //        if (criteria.isSortDescending()) {
 //          query.orderBy().category().descending();

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/TaskService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/TaskService.java
@@ -13,19 +13,17 @@ import static ch.ivyteam.ivy.workflow.TaskState.RESUMED;
 import static ch.ivyteam.ivy.workflow.TaskState.SUSPENDED;
 import static ch.ivyteam.ivy.workflow.TaskState.WAITING_FOR_INTERMEDIATE_EVENT;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.time.DateUtils;
 
 import com.axonivy.portal.bo.ItemByCategoryStatistic;
 
 import ch.ivy.addon.portalkit.bo.ExpiryStatistic;
+import ch.ivy.addon.portalkit.util.TimesUtils;
 import ch.ivy.addon.portalkit.bo.PriorityStatistic;
 import ch.ivy.addon.portalkit.bo.TaskStateStatistic;
 import ch.ivy.addon.portalkit.enums.AdditionalProperty;
@@ -37,7 +35,6 @@ import ch.ivy.addon.portalkit.util.CategoryUtils;
 import ch.ivy.addon.portalkit.util.PermissionUtils;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.persistence.query.IPagedResult;
-import ch.ivyteam.ivy.scripting.objects.Record;
 import ch.ivyteam.ivy.scripting.objects.Recordset;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.security.exec.Sudo;
@@ -158,16 +155,9 @@ public class TaskService {
     return Sudo.get(() -> {
       IvyTaskResultDTO result = new IvyTaskResultDTO();
       TaskQuery finalQuery = extendQueryWithUserCanWorkOn(criteria);
-      finalQuery.aggregate().countRows().groupBy().expiryTimestamp().orderBy().expiryTimestamp();
-
-      Recordset recordSet = taskQueryExecutor().getRecordset(finalQuery);
-      ExpiryStatistic expiryStatistic = null;
-      try {
-        expiryStatistic = createExpiryTimeStampToCountMap(recordSet);
-      } catch (ParseException e) {
-        Ivy.log().error(e);
-      }
-      result.setExpiryStatistic(expiryStatistic);
+      finalQuery.where().and().expiryTimestamp().isNotNull();
+      List<ITask> tasks = Ivy.wf().getTaskQueryExecutor().getResults(finalQuery);
+      result.setExpiryStatistic(createExpiryStatistic(tasks));
       return result;
     });
   }
@@ -208,44 +198,24 @@ public class TaskService {
     });
   }
 
-//  private TaskCategoryStatistic createTaskCategoryStatistic(Recordset recordSet) {
-//    TaskCategoryStatistic taskCategoryStatistic = new TaskCategoryStatistic();
-//    taskCategoryStatistic.setNumberOfTasksByCategory(new HashMap<>());
-//    if (recordSet != null) {
-//      recordSet.getRecords().forEach(record -> {
-//        long numberOfTasks = ((Number)(record.getField("COUNT"))).longValue();
-//        taskCategoryStatistic.getNumberOfTasksByCategory().put(record.getField("CATEGORY").toString(), numberOfTasks);
-//      });
-//    }
-//    return taskCategoryStatistic;
-//  }
-
-  private ExpiryStatistic createExpiryTimeStampToCountMap(Recordset recordSet) throws ParseException {
-      ExpiryStatistic expiryStatistic = new ExpiryStatistic();
-      Map<Date, Long> numberOfTasksByExpiryTime = new HashMap<>();
-      if (recordSet != null) {
-        for (Record record : recordSet.getRecords()) {
-          if (record.getField("EXPIRYTIMESTAMP") != null) {
-            // must use same format as IVY DB, can not change it to Ivy.cms().co("/patterns/dateTimePattern")
-            String pattern = "yyyy-MM-dd HH:mm:ss.SSS";
-
-            Date date = new Date();
-            try {
-              date = DateUtils.parseDate(record.getField("EXPIRYTIMESTAMP").toString(), pattern);
-            } catch(ParseException e) {
-              // Try to parse by MySQL specific date format
-              // Ticket: IVYPORTAL-14349
-              SimpleDateFormat mySqlDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-              date = mySqlDateFormat.parse(record.getField("EXPIRYTIMESTAMP").toString());
-            }
-            long numberOfTasks = ((Number)(record.getField("COUNT"))).longValue();
-            numberOfTasksByExpiryTime.put(date, numberOfTasks);
-          }
-        }
+  private ExpiryStatistic createExpiryStatistic(List<ITask> tasks) {
+    ExpiryStatistic expiryStatistic = new ExpiryStatistic();
+    long numberOfTasksExpiredToday = 0L;
+    long numberOfTasksExpiredThisWeek = 0L;
+    Date now = new Date();
+    for (ITask task : tasks) {
+      Date expiryDate = task.getExpiryTimestamp();
+      if (DateUtils.isSameDay(now, expiryDate)) {
+        numberOfTasksExpiredToday++;
+        numberOfTasksExpiredThisWeek++;
+      } else if (TimesUtils.isDateInCurrentWeek(expiryDate)) {
+        numberOfTasksExpiredThisWeek++;
       }
-      expiryStatistic.setNumberOfTasksByExpiryTime(numberOfTasksByExpiryTime);
-      return expiryStatistic;
     }
+    expiryStatistic.setNumberOfTasksExpiredToday(numberOfTasksExpiredToday);
+    expiryStatistic.setNumberOfTasksExpiredThisWeek(numberOfTasksExpiredThisWeek);
+    return expiryStatistic;
+  }
 
   private TaskQuery extendQueryWithUserHasPermissionToSee(
         TaskSearchCriteria criteria) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/jsf/Attrs.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/jsf/Attrs.java
@@ -1,7 +1,5 @@
 package ch.ivy.addon.portalkit.jsf;
 
-import javax.el.ELContext;
-import javax.el.ValueExpression;
 import javax.faces.context.FacesContext;
 
 /**
@@ -23,32 +21,16 @@ import javax.faces.context.FacesContext;
  */
 public class Attrs {
 
-  
-
-  private final FacesContext facesContext;
-
   private Attrs(FacesContext facesContext) {
     if (facesContext == null) {
       throw new IllegalArgumentException("FacesContext must not be null to use Attrs");
     }
-    this.facesContext = facesContext;
   }
   
   public static Attrs currentContext() {
     return new Attrs(FacesContext.getCurrentInstance());
   }
   
-  // This method is defined but not in used yet.
-  // Set it `public` and remove the `@SuppressWarning` if you want to publish it.
-  @SuppressWarnings("unused")
-  private void set(String attribute, Object value) {
-    ELContext elContext = facesContext.getELContext();
-    ValueExpression valueExpression =
-        facesContext.getApplication().getExpressionFactory()
-            .createValueExpression(elContext, "#{cc.attrs." + attribute + "}", Object.class);
-    valueExpression.setValue(elContext, value);
-  }
-
   public <T> T get(String attribute) {
     String attributeExpression = String.format("#{cc.attrs.%s}", attribute);
     return getAttribute(attributeExpression);

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/persistence/converter/BusinessEntityConverter.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/persistence/converter/BusinessEntityConverter.java
@@ -80,7 +80,7 @@ public class BusinessEntityConverter {
 
   public static <T> T inputStreamToEntity(InputStream inputStream, Class<T> classType) {
     try (InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
-      return getObjectMapper().readValue(inputStream, classType);
+      return getObjectMapper().readValue(reader, classType);
     } catch (IOException e) {
       throw new PortalException(e);
     }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/AiProcessService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/AiProcessService.java
@@ -2,7 +2,7 @@ package ch.ivy.addon.portalkit.service;
 
 import com.axonivy.portal.components.util.ProcessStartUtils;
 
-import ch.ivyteam.ivy.workflow.IProcessStart;
+import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 public class AiProcessService {
 
@@ -17,8 +17,8 @@ public class AiProcessService {
     return instance;
   }
 
-  public IProcessStart findAssistantDashboardProcess() {
-    return ProcessStartUtils.findProcessStartByUserFriendlyRequestPath(
+  public IWebStartable findAssistantDashboardProcess() {
+    return ProcessStartUtils.findWebStartableByUserFriendlyRequestPath(
         AI_DASHBOARD_FRIENDLY_REQUEST_PATH);
   }
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/CaseDocumentService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/CaseDocumentService.java
@@ -55,7 +55,7 @@ public class CaseDocumentService {
   public StreamedContent download(IvyDocument document) {
     return DefaultStreamedContent
         .builder()
-        .stream(() -> documentsOf(iCase).get(Long.valueOf(document.getId())).read().asStream())
+        .stream(() -> documentsOf(iCase).get(document.getUuid()).read().asStream())
         .contentType(document.getContentType())
         .name(document.getName())
         .build();

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/DashboardWidgetInformationService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/DashboardWidgetInformationService.java
@@ -75,7 +75,7 @@ public class DashboardWidgetInformationService {
   }
 
   private static Collector<Entry<TaskBusinessState, Long>, ?, LinkedHashMap<TaskBusinessState, Long>> collectToTaskStateMap() {
-    return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue,
+    return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, _) -> oldValue,
         LinkedHashMap::new);
   }
 
@@ -172,7 +172,7 @@ public class DashboardWidgetInformationService {
   }
 
   private Collector<Entry<CaseBusinessState, Long>, ?, LinkedHashMap<CaseBusinessState, Long>> collectToCaseStateMap() {
-    return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, newValue) -> oldValue,
+    return Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (oldValue, _) -> oldValue,
         LinkedHashMap::new);
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/DashboardWidgetInformationService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/DashboardWidgetInformationService.java
@@ -2,7 +2,6 @@ package ch.ivy.addon.portalkit.service;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -14,7 +13,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import com.axonivy.portal.enums.CaseQueryType;
-import org.apache.commons.lang3.time.DateUtils;
 
 import com.axonivy.portal.bo.ItemByCategoryStatistic;
 import com.axonivy.portal.components.service.IvyAdapterService;
@@ -32,7 +30,6 @@ import ch.ivy.addon.portalkit.enums.ProcessType;
 import ch.ivy.addon.portalkit.ivydata.searchcriteria.CaseSearchCriteria;
 import ch.ivy.addon.portalkit.ivydata.searchcriteria.TaskSearchCriteria;
 import ch.ivy.addon.portalkit.util.PermissionUtils;
-import ch.ivy.addon.portalkit.util.TimesUtils;
 import ch.ivyteam.ivy.workflow.caze.CaseBusinessState;
 import ch.ivyteam.ivy.workflow.task.TaskBusinessState;
 
@@ -80,26 +77,15 @@ public class DashboardWidgetInformationService {
   }
 
   public Map<String, Long> buildStatisticOfTaskExpiry(DashboardTaskLazyDataModel dataModel) {
-    Map<String, Long> numberOfTasksExpireMap = new HashMap<>();
-    long numberOfTasksExpireToday = 0L;
-    long numberOfTasksExpireThisWeek = 0L;
-
     Map<String, Object> params = new HashMap<>();
     params.put("taskSearchCriteria", generateTaskSearchCriteriaWithoutOrderByClause(dataModel));
 
     Map<String, Object> response = IvyAdapterService.startSubProcessInProjectAndAllRequired(ANALYZE_TASK_EXPIRY, params);
     var expiryStatistic = (ExpiryStatistic) response.get("expiryStatistic");
 
-    for (Entry<Date, Long> entry : expiryStatistic.getNumberOfTasksByExpiryTime().entrySet()) {
-      if (DateUtils.isSameDay(new Date(), entry.getKey())) {
-        numberOfTasksExpireToday++;
-        numberOfTasksExpireThisWeek++;
-      } else if (TimesUtils.isDateInCurrentWeek(entry.getKey())) {
-        numberOfTasksExpireThisWeek++;
-      }
-    }
-    numberOfTasksExpireMap.put(TASKS_EXPIRE_TODAY, numberOfTasksExpireToday);
-    numberOfTasksExpireMap.put(TASKS_EXPIRE_THIS_WEEK, numberOfTasksExpireThisWeek);
+    Map<String, Long> numberOfTasksExpireMap = new HashMap<>();
+    numberOfTasksExpireMap.put(TASKS_EXPIRE_TODAY, expiryStatistic.getNumberOfTasksExpiredToday());
+    numberOfTasksExpireMap.put(TASKS_EXPIRE_THIS_WEEK, expiryStatistic.getNumberOfTasksExpiredThisWeek());
     return numberOfTasksExpireMap;
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/ExternalLinkService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/ExternalLinkService.java
@@ -31,6 +31,7 @@ public class ExternalLinkService extends JsonConfigurationService<ExternalLink> 
     return findAll().stream().filter(link -> externalLinkName.equals(link.getName())).findFirst().orElse(null);
   }
 
+  @SuppressWarnings("removal")
   public List<ExternalLink> filterPublicExternalLinksForIvySessionUser() {
     IUser sessionUser = Ivy.session().getSessionUser();
     return ExternalLinkService.getInstance().getPublicConfig().stream()
@@ -39,6 +40,7 @@ public class ExternalLinkService extends JsonConfigurationService<ExternalLink> 
         .collect(Collectors.toList());
   }
 
+  @SuppressWarnings("removal")
   public List<ExternalLink> filterPublicExternalLinksNotForIvySessionUser() {
     IUser sessionUser = Ivy.session().getSessionUser();
     return ExternalLinkService.getInstance().getPublicConfig().stream()

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/IvyCacheService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/IvyCacheService.java
@@ -147,7 +147,6 @@ public class IvyCacheService {
    * This method will invalidate global configuration cache store in application cache
    * @param cacheGroupName
    */
-  //TODO: after switch to application scope for all configuration, we don't need this method, just clear cache on current app
   public void invalidateApplicationCacheForAllAvailableApplications(String cacheGroupName) {
     try {
       Sudo.run(() -> {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/CustomWidgetUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/CustomWidgetUtils.java
@@ -61,6 +61,7 @@ public class CustomWidgetUtils {
     return getPropertyByKeyPattern(task.getId(), keyPattern);
   }
 
+  @SuppressWarnings("removal")
   public static String getUserPropertyByKeyPattern(IUser user, String keyPattern) {
     return getPropertyByKeyPattern(user.getId(), keyPattern);
   }
@@ -103,6 +104,7 @@ public class CustomWidgetUtils {
     return propertyValue;
   }
 
+  @SuppressWarnings("removal")
   private static String getUserPropertyKey(Long referenceId, String[] keyParts) {
     String propertyValue = EMPTY;
     IUser user =  UserUtils.findUserByUserId(referenceId);

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DashboardUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DashboardUtils.java
@@ -120,7 +120,7 @@ public class DashboardUtils {
     }
 
     List<Dashboard> mappingDashboards = convertDashboardsToLatestVersion(dashboardJSON);
-    mappingDashboards.forEach(dashboard -> initDefaultPermission());
+    mappingDashboards.forEach(_ -> initDefaultPermission());
     return mappingDashboards;
   }
 

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DashboardWidgetUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DashboardWidgetUtils.java
@@ -580,6 +580,7 @@ public class DashboardWidgetUtils {
     return publicExternalLinksNotForIvySessionUser.stream().map(link -> link.getId()).toList();
   }
 
+  @SuppressWarnings("removal")
   private static void updateProcessStartIdForCombined(ProcessDashboardWidget processWidget, DashboardProcess process) {
     if (processWidget.getDisplayMode() == ProcessWidgetMode.COMBINED_MODE && process.getProcessStartId() == null) {
       Ivy.session().getStartableProcessStarts().stream()

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DashboardWidgetUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DashboardWidgetUtils.java
@@ -404,7 +404,7 @@ public class DashboardWidgetUtils {
   }
 
 
-  private static DashboardWidget buildDefaultStatisticWidget(String id, @SuppressWarnings("unused") String name, @SuppressWarnings("unused") DashboardWidgetType widgetType) {
+  private static DashboardWidget buildDefaultStatisticWidget(String id, String name, DashboardWidgetType widgetType) {
     DashboardWidget widget = null;
     widget = new StatisticDashboardWidget();
     widget.setId(id);

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DeputyRoleUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DeputyRoleUtils.java
@@ -33,7 +33,7 @@ public class DeputyRoleUtils {
         IRole substitutionRole = ivySubstitute.getSubstitionRole();
         DeputyRoleType deputyRoleType = null;
         if (substitutionRole != null) {
-          deputyRoleKey = String.valueOf(substitutionRole.getId());
+          deputyRoleKey = substitutionRole.getSecurityMemberId();
           deputyRoleType = DeputyRoleType.TASK_FOR_ROLE;
         } else if(SubstitutionType.PERMANENT.equals(ivySubstitute.getSubstitutionType())) {
           deputyRoleKey = personalTaskPermanentKey;

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DisplayNameAdaptor.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/DisplayNameAdaptor.java
@@ -26,7 +26,6 @@ public class DisplayNameAdaptor {
 		return displayNameConvertor;
 	}
 
-  @SuppressWarnings("unused")
   private boolean isValidJson(String jsonString) {
 		try {
 			new JSONObject(jsonString);

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/SecurityServiceUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/SecurityServiceUtils.java
@@ -3,7 +3,6 @@ package ch.ivy.addon.portalkit.util;
 import com.axonivy.portal.components.publicapi.ProcessStartAPI;
 
 import ch.ivyteam.ivy.environment.Ivy;
-import ch.ivyteam.ivy.server.restricted.EngineMode;
 
 /**
  * Utility for security service.
@@ -33,12 +32,4 @@ public class SecurityServiceUtils {
     Ivy.session().removeAttribute(name);
   }
 
-  /**
-   * Check current engine is designer or not.
-   * 
-   * @return check result
-   */
-  public static boolean isDesigner() {
-    return EngineMode.isEmbeddedInDesigner();
-  }
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UserUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UserUtils.java
@@ -215,6 +215,7 @@ public class UserUtils {
    * @param userId
    * @return {@link IUser}
    */
+  @SuppressWarnings("removal")
   @Deprecated(forRemoval = true, since = "11.2.0")
   public static IUser findUserByUserId(Long userId) {
     return Sudo.get(() -> {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/StatisticConfigurationBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/StatisticConfigurationBean.java
@@ -48,7 +48,6 @@ import com.axonivy.portal.components.publicapi.PortalNavigatorAPI;
 import com.axonivy.portal.components.service.DateTimeGlobalSettingService;
 import com.axonivy.portal.components.util.FacesMessageUtils;
 import com.axonivy.portal.components.util.RoleUtils;
-import com.axonivy.portal.constant.StatisticConstants;
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.statistic.AggregationField;
@@ -84,7 +83,6 @@ import ch.ivy.addon.portalkit.util.LanguageUtils.NameResult;
 import ch.ivy.addon.portalkit.util.SecurityMemberUtils;
 import ch.ivy.addon.portalkit.util.UserUtils;
 import ch.ivyteam.ivy.environment.Ivy;
-import ch.ivyteam.ivy.searchengine.client.agg.AggregationResult;
 import ch.ivyteam.ivy.security.ISecurityConstants;
 import ch.ivyteam.ivy.security.ISecurityContext;
 import ch.ivyteam.ivy.workflow.custom.field.CustomFieldType;
@@ -405,7 +403,7 @@ public class StatisticConfigurationBean implements Serializable, IMultiLanguage 
     if (CollectionUtils.isNotEmpty(responsibles)) {
       Collection<SecurityMemberDTO> distinctPermissionDTOs =
           responsibles.stream().collect(Collectors.toMap(SecurityMemberDTO::getMemberName, responsible -> responsible,
-              (responsible1, responsible2) -> responsible1)).values();
+              (responsible1, _) -> responsible1)).values();
       responsibles.clear();
       responsibles.addAll(distinctPermissionDTOs);
       permissions = responsibles.stream().map(SecurityMemberDTO::getMemberName).collect(Collectors.toList());

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/DashboardImportBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/DashboardImportBean.java
@@ -1,6 +1,5 @@
 package com.axonivy.portal.bean.dashboard;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +39,7 @@ import ch.ivyteam.ivy.security.IRole;
 
 @ViewScoped
 @ManagedBean
-public class DashboardImportBean extends DashboardModificationBean implements Serializable {
+public class DashboardImportBean extends DashboardModificationBean {
   private static final long serialVersionUID = 1L;
   private boolean isLoaded = false;
   private UploadedFile importFile;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetIdFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetIdFilterBean.java
@@ -21,6 +21,6 @@ public class WidgetIdFilterBean implements Serializable {
     return operators;
   }
 
-  public void onChangeOperator(@SuppressWarnings("unused") DashboardFilter filter) {
+  public void onChangeOperator(DashboardFilter filter) {
   }
 }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
@@ -33,7 +33,7 @@ public class WidgetTextFilterBean implements Serializable {
     return operatorsForCustomFieldWithCms;
   }
 
-  public void onChangeOperator(@SuppressWarnings("unused") DashboardFilter filter) {
+  public void onChangeOperator(DashboardFilter filter) {
   }
 
   public boolean isShowTextListPanel(DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/CaseWidgetConfigurationFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/CaseWidgetConfigurationFilterBean.java
@@ -2,7 +2,6 @@ package com.axonivy.portal.bean.dashboard.filter;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +22,7 @@ import ch.ivyteam.ivy.workflow.caze.CaseBusinessState;
 
 @ManagedBean
 @ViewScoped
-public class CaseWidgetConfigurationFilterBean extends AbstractCaseWidgetFilterBean implements Serializable {
+public class CaseWidgetConfigurationFilterBean extends AbstractCaseWidgetFilterBean {
 
   private static final long serialVersionUID = 988060141286387861L;
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/CaseWidgetUserFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/CaseWidgetUserFilterBean.java
@@ -1,6 +1,5 @@
 package com.axonivy.portal.bean.dashboard.filter;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -18,7 +17,7 @@ import ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget;
 
 @ManagedBean
 @ViewScoped
-public class CaseWidgetUserFilterBean extends AbstractCaseWidgetFilterBean implements Serializable {
+public class CaseWidgetUserFilterBean extends AbstractCaseWidgetFilterBean {
 
   private static final long serialVersionUID = 7812171996900852992L;
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/TaskWidgetConfigurationFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/TaskWidgetConfigurationFilterBean.java
@@ -2,7 +2,6 @@ package com.axonivy.portal.bean.dashboard.filter;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +23,7 @@ import ch.ivyteam.ivy.workflow.task.TaskBusinessState;
 
 @ManagedBean
 @ViewScoped
-public class TaskWidgetConfigurationFilterBean extends AbstractTaskWidgetFilterBean implements Serializable {
+public class TaskWidgetConfigurationFilterBean extends AbstractTaskWidgetFilterBean {
 
   private static final long serialVersionUID = -6820861008506479795L;
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/TaskWidgetUserFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/TaskWidgetUserFilterBean.java
@@ -1,6 +1,5 @@
 package com.axonivy.portal.bean.dashboard.filter;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -19,7 +18,7 @@ import ch.ivy.addon.portalkit.dto.dashboard.TaskDashboardWidget;
 
 @ManagedBean
 @ViewScoped
-public class TaskWidgetUserFilterBean extends AbstractTaskWidgetFilterBean implements Serializable {
+public class TaskWidgetUserFilterBean extends AbstractTaskWidgetFilterBean {
 
   private static final long serialVersionUID = 2329063671455796253L;
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/NavigationDashboardWidget.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/NavigationDashboardWidget.java
@@ -1,6 +1,5 @@
 package com.axonivy.portal.dto.dashboard;
 
-import java.io.Serializable;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -13,7 +12,7 @@ import ch.ivy.addon.portalkit.enums.VisualType;
 import ch.ivy.addon.portalkit.util.LanguageUtils;
 import ch.ivy.addon.portalkit.util.LanguageUtils.NameResult;
 
-public class NavigationDashboardWidget extends DashboardWidget implements Serializable {
+public class NavigationDashboardWidget extends DashboardWidget {
   
   private static final long serialVersionUID = -565012312312361L;
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/NewsDashboardWidget.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/NewsDashboardWidget.java
@@ -1,6 +1,5 @@
 package com.axonivy.portal.dto.dashboard;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,7 +13,7 @@ import ch.ivy.addon.portalkit.enums.DashboardWidgetType;
 import ch.ivy.addon.portalkit.util.LanguageUtils;
 import ch.ivy.addon.portalkit.util.LanguageUtils.NameResult;
 
-public class NewsDashboardWidget extends DashboardWidget implements Serializable {
+public class NewsDashboardWidget extends DashboardWidget {
 
   private static final long serialVersionUID = -5650954020648136966L;
   @JsonIgnore

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/filter/DashboardFilter.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/filter/DashboardFilter.java
@@ -1,6 +1,5 @@
 package com.axonivy.portal.dto.dashboard.filter;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -22,7 +21,7 @@ import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivy.addon.portalkit.ivydata.utils.ServiceUtilities;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public class DashboardFilter extends BaseFilter implements Serializable {
+public class DashboardFilter extends BaseFilter {
   private static final long serialVersionUID = -2098346832426240167L;
   @JsonIgnore
   public static final String APPLICATION = "application";

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/migration/common/search/JsonDashboardConfigurationSearch.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/migration/common/search/JsonDashboardConfigurationSearch.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 public class JsonDashboardConfigurationSearch {
   private final JsonNode configuration;
 
-  private Predicate<JsonNode> filter = e -> true;
+  private Predicate<JsonNode> filter = _ -> true;
 
   public JsonDashboardConfigurationSearch(JsonNode configuration) {
     this.configuration = configuration;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/migration/common/search/JsonWidgetSearch.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/migration/common/search/JsonWidgetSearch.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 public class JsonWidgetSearch {
   private final JsonNode dashboard;
 
-  private Predicate<JsonNode> filter = e -> true;
+  private Predicate<JsonNode> filter = _ -> true;
 
   public JsonWidgetSearch(JsonNode dashboard) {
     this.dashboard = dashboard;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/customfield/CustomStringContainsOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/customfield/CustomStringContainsOperatorHandler.java
@@ -29,7 +29,7 @@ public class CustomStringContainsOperatorHandler {
     if (CollectionUtils.isEmpty(filter.getValues())) {
       return null;
     }
-    CaseQuery query = CaseQuery.create(); // TODO filterfield correct? business and/or technical cases?
+    CaseQuery query = CaseQuery.create();
 
     filter.getValues().forEach(text -> {
       CaseQuery subQuery = CaseQuery.create();

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/customfield/CustomTextContainsOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/customfield/CustomTextContainsOperatorHandler.java
@@ -23,7 +23,7 @@ public class CustomTextContainsOperatorHandler {
     if (CollectionUtils.isEmpty(filter.getValues())) {
       return null;
     }
-    CaseQuery query = CaseQuery.create(); // TODO filterfield correct? business and/or technical cases?
+    CaseQuery query = CaseQuery.create();
     filter.getValues().forEach(text -> {
       CaseQuery subQuery = CaseQuery.create();
       subQuery.where().customField().textField(filter.getField())

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/description/DescriptionIsEmptyOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/description/DescriptionIsEmptyOperatorHandler.java
@@ -15,13 +15,13 @@ public class DescriptionIsEmptyOperatorHandler {
     return instance;
   }
 
-  public CaseQuery buildIsEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public CaseQuery buildIsEmptyQuery(DashboardFilter filter) {
     CaseQuery subQuery = CaseQuery.create();
     subQuery.where().description().isNull().or().description().isLike("");
     return subQuery;
   }
 
-  public CaseQuery buildNotEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public CaseQuery buildNotEmptyQuery(DashboardFilter filter) {
     CaseQuery subQuery = CaseQuery.create();
     subQuery.where().description().isNotNull().and().description().isNotLike("");
     return subQuery;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/name/NameIsEmptyOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/caze/name/NameIsEmptyOperatorHandler.java
@@ -15,13 +15,13 @@ public class NameIsEmptyOperatorHandler {
     return instance;
   }
 
-  public CaseQuery buildIsEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public CaseQuery buildIsEmptyQuery(DashboardFilter filter) {
     CaseQuery subQuery = CaseQuery.create();
     subQuery.where().name().isNull().or().name().isLike("");
     return subQuery;
   }
 
-  public CaseQuery buildNotEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public CaseQuery buildNotEmptyQuery(DashboardFilter filter) {
     CaseQuery subQuery = CaseQuery.create();
     subQuery.where().name().isNotNull().and().name().isNotLike("");
     return subQuery;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/customfield/CustomStringContainsOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/customfield/CustomStringContainsOperatorHandler.java
@@ -28,7 +28,7 @@ public class CustomStringContainsOperatorHandler {
     if (CollectionUtils.isEmpty(filter.getValues())) {
       return null;
     }
-    TaskQuery query = TaskQuery.create(); // TODO filterfield correct? business and/or technical cases?
+    TaskQuery query = TaskQuery.create();
 
     filter.getValues().forEach(text -> {
       TaskQuery subQuery = TaskQuery.create();

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/customfield/CustomTextContainsOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/customfield/CustomTextContainsOperatorHandler.java
@@ -25,7 +25,7 @@ public class CustomTextContainsOperatorHandler {
     if (CollectionUtils.isEmpty(filter.getValues())) {
       return null;
     }
-    TaskQuery query = TaskQuery.create(); // TODO filterfield correct? business and/or technical cases?
+    TaskQuery query = TaskQuery.create();
     filter.getValues().forEach(text -> {
       TaskQuery subQuery = TaskQuery.create();
       subQuery.where().customField().textField(filter.getField())

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/description/DescriptionIsEmptyOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/description/DescriptionIsEmptyOperatorHandler.java
@@ -15,13 +15,13 @@ public class DescriptionIsEmptyOperatorHandler {
     return instance;
   }
 
-  public TaskQuery buildIsEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public TaskQuery buildIsEmptyQuery(DashboardFilter filter) {
     TaskQuery subQuery = TaskQuery.create();
     subQuery.where().description().isNull().or().description().isLike("");
     return subQuery;
   }
 
-  public TaskQuery buildNotEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public TaskQuery buildNotEmptyQuery(DashboardFilter filter) {
     TaskQuery subQuery = TaskQuery.create();
     subQuery.where().description().isNotNull().and().description().isNotLike("");
     return subQuery;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/name/NameIsEmptyOperatorHandler.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/filter/operator/task/name/NameIsEmptyOperatorHandler.java
@@ -15,13 +15,13 @@ public class NameIsEmptyOperatorHandler {
     return instance;
   }
 
-  public TaskQuery buildIsEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public TaskQuery buildIsEmptyQuery(DashboardFilter filter) {
     TaskQuery subQuery = TaskQuery.create();
     subQuery.where().name().isNull().or().name().isLike("");
     return subQuery;
   }
 
-  public TaskQuery buildNotEmptyQuery(@SuppressWarnings("unused") DashboardFilter filter) {
+  public TaskQuery buildNotEmptyQuery(DashboardFilter filter) {
     TaskQuery subQuery = TaskQuery.create();
     subQuery.where().name().isNotNull().and().name().isNotLike("");
     return subQuery;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/statisticfilter/field/task/TaskFilterFieldCanWorkOn.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/statisticfilter/field/task/TaskFilterFieldCanWorkOn.java
@@ -48,13 +48,11 @@ public class TaskFilterFieldCanWorkOn extends FilterField{
 
   @Override
   public CaseQuery generateFilterQuery(DashboardFilter filter) {
-    // TODO Auto-generated method stub
     return null;
   }
 
   @Override
   public TaskQuery generateFilterTaskQuery(DashboardFilter filter) {
-    // TODO Auto-generated method stub
     return null;
   }
 

--- a/Showcase/portal-components-examples/processes/Start Processes/ProcessViewerExample.p.json
+++ b/Showcase/portal-components-examples/processes/Start Processes/ProcessViewerExample.p.json
@@ -16,10 +16,9 @@
             "import com.axonivy.portal.components.util.ProcessStartUtils;",
             "import ch.ivyteam.ivy.workflow.ICase;",
             "import ch.ivyteam.ivy.workflow.query.CaseQuery;",
-            "import ch.ivyteam.ivy.workflow.IProcessStart;",
             "",
-            "IProcessStart processStart = ProcessStartUtils.findProcessStartByUserFriendlyRequestPath(\"Start Processes/LeaveRequest/start.ivp\");",
-            "CaseQuery caseQuery = CaseQuery.businessCases().where().taskStartId().isEqual(processStart.getTaskStart().getId()).orderBy().caseId().descendingNullLast();",
+            "Long taskStartId = ProcessStartUtils.findTaskStartIdByUserFriendlyRequestPath(\"Start Processes/LeaveRequest/start.ivp\");",
+            "CaseQuery caseQuery = CaseQuery.businessCases().where().taskStartId().isEqual(taskStartId).orderBy().caseId().descendingNullLast();",
             "ICase caze = ivy.wf.getCaseQueryExecutor().getFirstResult(caseQuery) as ICase;",
             "out.selectedCaseId = caze != null ? caze.getId() : 0;"
           ]
@@ -145,10 +144,9 @@
             "import ch.ivyteam.ivy.workflow.ICase;",
             "import ch.ivyteam.ivy.workflow.ITask;",
             "import ch.ivyteam.ivy.workflow.query.CaseQuery;",
-            "import ch.ivyteam.ivy.workflow.IProcessStart;",
             "",
-            "IProcessStart processStart = ProcessStartUtils.findProcessStartByUserFriendlyRequestPath(\"Start Processes/LeaveRequest/start.ivp\");",
-            "CaseQuery caseQuery = CaseQuery.businessCases().where().taskStartId().isEqual(processStart.getTaskStart().getId()).orderBy().caseId().descendingNullLast();",
+            "Long taskStartId = ProcessStartUtils.findTaskStartIdByUserFriendlyRequestPath(\"Start Processes/LeaveRequest/start.ivp\");",
+            "CaseQuery caseQuery = CaseQuery.businessCases().where().taskStartId().isEqual(taskStartId).orderBy().caseId().descendingNullLast();",
             "ICase caze = ivy.wf.getCaseQueryExecutor().getFirstResult(caseQuery) as ICase;",
             "List<ITask> openTasks = TaskUtils.getOpenTasksByCase(caze);",
             "out.selectedTaskId = openTasks.size() > 0 ? openTasks.get(0).getId() : 0;"

--- a/Showcase/portal-components-examples/src/com/axonivy/portal/components/examples/document/CustomizedIvyDocumentTransformer.java
+++ b/Showcase/portal-components-examples/src/com/axonivy/portal/components/examples/document/CustomizedIvyDocumentTransformer.java
@@ -14,7 +14,6 @@ public class CustomizedIvyDocumentTransformer {
   public CustomizedIvyDocument transform(IDocument document) {
     CustomizedIvyDocument result = new CustomizedIvyDocument();
 
-    result.setId(String.valueOf(document.getId()));
     result.setName(document.getName());
     result.setPath(document.getPath().asString());
     result.setRelativePath(document.getRelativePath().asString());


### PR DESCRIPTION
This PR (IVYPORTAL-20070) aims to reduce compiler/static-analysis warnings across Portal modules by removing unused code/imports, updating deprecated API usages (notably around workflow startables and document identifiers), and cleaning up TODO/suppression noise.

**Changes:**
- Replace deprecated ID-based document handling with UUID-based access in document transformers and download services.
- Migrate process-start lookups from `IProcessStart` to `IWebStartable` and adjust navigation/link building accordingly.
- Remove unused `Serializable` declarations/imports and other unused code, and add targeted `@SuppressWarnings("removal")` where deprecated-for-removal APIs are still required.