### PR TITLE
IVYPORTAL-20451 Use PDFBox instead of outdated itextpdf

### DIFF
--- a/AxonIvyPortal/portal-components/pom.xml
+++ b/AxonIvyPortal/portal-components/pom.xml
@@ -32,9 +32,9 @@
       <version>1.21.2</version>
     </dependency>
     <dependency>
-      <groupId>com.itextpdf</groupId>
-      <artifactId>itextpdf</artifactId>
-      <version>5.5.13.4</version>
+      <groupId>org.apache.pdfbox</groupId>
+      <artifactId>pdfbox</artifactId>
+      <version>3.0.7</version>
     </dependency>
     <dependency>
       <groupId>com.axonivy.ivy.api</groupId>

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
@@ -7,6 +7,7 @@ import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 
 import ch.ivyteam.ivy.bpm.error.BpmError;
 import ch.ivyteam.ivy.environment.Ivy;
@@ -32,7 +33,7 @@ public class PDFDocumentDetector implements DocumentDetector {
       boolean hasOpenAction = root.getDictionaryObject(COSName.OPEN_ACTION) != null;
 
       return !hasEmbeddedFiles && !hasAcroForm && !hasOpenAction;
-    } catch (NoClassDefFoundError e) {
+    } catch (InvalidPasswordException e) {
       Ivy.log().error("This file is encrypted and cannot be scanned for security threats before uploading.");
       BpmError.create("portal:file:encrypted").throwError();
     } catch (Exception e) {

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
@@ -2,10 +2,11 @@ package com.axonivy.portal.components.document;
 
 import java.io.InputStream;
 
-import com.itextpdf.text.pdf.PdfArray;
-import com.itextpdf.text.pdf.PdfDictionary;
-import com.itextpdf.text.pdf.PdfName;
-import com.itextpdf.text.pdf.PdfReader;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
 
 import ch.ivyteam.ivy.bpm.error.BpmError;
 import ch.ivyteam.ivy.environment.Ivy;
@@ -14,57 +15,48 @@ public class PDFDocumentDetector implements DocumentDetector {
 
   @Override
   public boolean isSafe(InputStream inputStream) {
-    boolean safeState = false;
-    PdfReader reader = null;
-    try {
-      if (inputStream != null) {
-        reader = new PdfReader(inputStream);
-
-        // Check 1: Detect JavaScript execution
-        String jsCode = reader.getJavaScript();
-        if (jsCode == null || jsCode.trim().isEmpty()) {
-
-          // Check 2: Detect embedded files
-          PdfDictionary root = reader.getCatalog();
-          PdfDictionary names = root.getAsDict(PdfName.NAMES);
-          PdfArray namesArray = checkEmbeddedFilesInPDF(names);
-
-          // Check 3: Detect AcroForms (forms can trigger JavaScript)
-          PdfDictionary acroForm = root.getAsDict(PdfName.ACROFORM);
-          boolean hasAcroForm = (acroForm != null);
-
-          // Check 4: Detect OpenAction (auto-trigger scripts)
-          PdfDictionary openAction = root.getAsDict(PdfName.OPENACTION);
-          boolean hasOpenAction = (openAction != null);
-
-          // Safe if no JS, no embedded files, no AcroForms, and no OpenAction
-          safeState = (namesArray == null || namesArray.isEmpty()) && !hasAcroForm && !hasOpenAction;
-        }
-      }
+    if (inputStream == null) {
+      return false;
     }
-    catch (NoClassDefFoundError e) {
+    try (PDDocument document = Loader.loadPDF(inputStream.readAllBytes())) {
+      COSDictionary root = document.getDocumentCatalog().getCOSObject();
+
+      if (detectJavaScript(root)) {
+        return false;
+      }
+
+      COSDictionary names = root.getCOSDictionary(COSName.NAMES);
+      COSArray embeddedFiles = getEmbeddedFiles(names);
+      boolean hasEmbeddedFiles = embeddedFiles != null && embeddedFiles.size() > 0;
+      boolean hasAcroForm = root.getCOSDictionary(COSName.ACRO_FORM) != null;
+      boolean hasOpenAction = root.getDictionaryObject(COSName.OPEN_ACTION) != null;
+
+      return !hasEmbeddedFiles && !hasAcroForm && !hasOpenAction;
+    } catch (NoClassDefFoundError e) {
       Ivy.log().error("This file is encrypted and cannot be scanned for security threats before uploading.");
       BpmError.create("portal:file:encrypted").throwError();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       Ivy.log().error("PDF security check failed", e);
-      safeState = false;
-    } finally {
-      if (reader != null) {
-        reader.close();
-      }
     }
-    return safeState;
+    return false;
   }
 
-  private PdfArray checkEmbeddedFilesInPDF(PdfDictionary names) {
-    PdfArray namesArr = null;
-    if (names != null) {
-      PdfDictionary embeddedFiles = names.getAsDict(PdfName.EMBEDDEDFILES);
-      if (embeddedFiles != null) {
-        namesArr = embeddedFiles.getAsArray(PdfName.NAMES);
-      }
+  private boolean detectJavaScript(COSDictionary root) {
+    COSDictionary names = root.getCOSDictionary(COSName.NAMES);
+    if (names != null && names.getCOSDictionary(COSName.getPDFName("JavaScript")) != null) {
+      return true;
     }
-    return namesArr;
+    return root.getCOSDictionary(COSName.AA) != null;
+  }
+
+  private COSArray getEmbeddedFiles(COSDictionary names) {
+    if (names == null) {
+      return null;
+    }
+    COSDictionary embeddedFiles = names.getCOSDictionary(COSName.EMBEDDED_FILES);
+    if (embeddedFiles == null) {
+      return null;
+    }
+    return (COSArray) embeddedFiles.getDictionaryObject(COSName.NAMES);
   }
 }

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
@@ -1,13 +1,18 @@
 package com.axonivy.portal.components.document;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.pdfbox.Loader;
-import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDDocumentNameDictionary;
+import org.apache.pdfbox.pdmodel.PDEmbeddedFilesNameTreeNode;
+import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
+import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 
 import ch.ivyteam.ivy.bpm.error.BpmError;
 import ch.ivyteam.ivy.environment.Ivy;
@@ -20,19 +25,10 @@ public class PDFDocumentDetector implements DocumentDetector {
       return false;
     }
     try (PDDocument document = Loader.loadPDF(inputStream.readAllBytes())) {
-      COSDictionary root = document.getDocumentCatalog().getCOSObject();
-
-      if (detectJavaScript(root)) {
-        return false;
-      }
-
-      COSDictionary names = root.getCOSDictionary(COSName.NAMES);
-      COSArray embeddedFiles = getEmbeddedFiles(names);
-      boolean hasEmbeddedFiles = embeddedFiles != null && embeddedFiles.size() > 0;
-      boolean hasAcroForm = root.getCOSDictionary(COSName.ACRO_FORM) != null;
-      boolean hasOpenAction = root.getDictionaryObject(COSName.OPEN_ACTION) != null;
-
-      return !hasEmbeddedFiles && !hasAcroForm && !hasOpenAction;
+      return !containsJavaScript(document)
+          && !containsEmbeddedFiles(document)
+          && !containsAcroForm(document)
+          && !containsOpenAction(document);
     } catch (InvalidPasswordException e) {
       Ivy.log().error("This file is encrypted and cannot be scanned for security threats before uploading.");
       BpmError.create("portal:file:encrypted").throwError();
@@ -42,22 +38,82 @@ public class PDFDocumentDetector implements DocumentDetector {
     return false;
   }
 
-  private boolean detectJavaScript(COSDictionary root) {
-    COSDictionary names = root.getCOSDictionary(COSName.NAMES);
-    if (names != null && names.getCOSDictionary(COSName.JAVA_SCRIPT) != null) {
+  private boolean containsJavaScript(PDDocument document) throws IOException {
+    if (hasCatalogLevelJavaScript(document)) {
       return true;
     }
-    return root.getCOSDictionary(COSName.AA) != null;
+    return hasPageOrAnnotationJavaScript(document);
   }
 
-  private COSArray getEmbeddedFiles(COSDictionary names) {
-    if (names == null) {
-      return null;
+  private boolean hasCatalogLevelJavaScript(PDDocument document) {
+    COSDictionary catalog = document.getDocumentCatalog().getCOSObject();
+    COSDictionary names = catalog.getCOSDictionary(COSName.NAMES);
+    boolean hasJavaScriptNameTree = names != null && names.getCOSDictionary(COSName.JAVA_SCRIPT) != null;
+    boolean hasCatalogAdditionalActions = catalog.getCOSDictionary(COSName.AA) != null;
+    return hasJavaScriptNameTree || hasCatalogAdditionalActions;
+  }
+
+  private boolean hasPageOrAnnotationJavaScript(PDDocument document) throws IOException {
+    for (PDPage page : document.getPages()) {
+      if (hasJavaScriptInActions(page.getCOSObject())) {
+        return true;
+      }
+      for (PDAnnotation annotation : page.getAnnotations()) {
+        if (hasJavaScriptInActions(annotation.getCOSObject())) {
+          return true;
+        }
+      }
     }
-    COSDictionary embeddedFiles = names.getCOSDictionary(COSName.EMBEDDED_FILES);
-    if (embeddedFiles == null) {
-      return null;
+    return false;
+  }
+
+  private boolean hasJavaScriptInActions(COSDictionary cosObject) {
+    if (hasJavaScriptInAdditionalActions(cosObject)) {
+      return true;
     }
-    return (COSArray) embeddedFiles.getDictionaryObject(COSName.NAMES);
+    COSDictionary directAction = cosObject.getCOSDictionary(COSName.A);
+    return directAction != null && isJavaScriptAction(directAction);
+  }
+
+  private boolean hasJavaScriptInAdditionalActions(COSDictionary cosObject) {
+    COSDictionary additionalActions = cosObject.getCOSDictionary(COSName.AA);
+    if (additionalActions == null) {
+      return false;
+    }
+    for (COSName key : additionalActions.keySet()) {
+      COSBase actionEntry = additionalActions.getDictionaryObject(key);
+      if (actionEntry instanceof COSDictionary && isJavaScriptAction((COSDictionary) actionEntry)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isJavaScriptAction(COSDictionary action) {
+    COSBase actionType = action.getDictionaryObject(COSName.S);
+    return COSName.JAVA_SCRIPT.equals(actionType);
+  }
+
+  private boolean containsEmbeddedFiles(PDDocument document) {
+    PDDocumentNameDictionary namesDictionary = document.getDocumentCatalog().getNames();
+    if (namesDictionary == null) {
+      return false;
+    }
+    PDEmbeddedFilesNameTreeNode embeddedFilesTree = namesDictionary.getEmbeddedFiles();
+    if (embeddedFilesTree == null) {
+      return false;
+    }
+    COSDictionary treeNode = embeddedFilesTree.getCOSObject();
+    return treeNode.containsKey(COSName.NAMES) || treeNode.containsKey(COSName.KIDS);
+  }
+
+  private boolean containsAcroForm(PDDocument document) {
+    COSDictionary catalog = document.getDocumentCatalog().getCOSObject();
+    return catalog.getCOSDictionary(COSName.ACRO_FORM) != null;
+  }
+
+  private boolean containsOpenAction(PDDocument document) {
+    COSDictionary catalog = document.getDocumentCatalog().getCOSObject();
+    return catalog.getDictionaryObject(COSName.OPEN_ACTION) != null;
   }
 }

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
@@ -50,8 +50,8 @@ public class PDFDocumentDetector implements DocumentDetector {
     COSDictionary catalog = document.getDocumentCatalog().getCOSObject();
     COSDictionary names = catalog.getCOSDictionary(COSName.NAMES);
     boolean hasJavaScriptNameTree = names != null && names.getCOSDictionary(COSName.JAVA_SCRIPT) != null;
-    boolean hasCatalogAdditionalActions = catalog.getCOSDictionary(COSName.AA) != null;
-    return hasJavaScriptNameTree || hasCatalogAdditionalActions;
+    boolean hasCatalogJavaScriptActions = hasJavaScriptInAdditionalActions(catalog);
+    return hasJavaScriptNameTree || hasCatalogJavaScriptActions;
   }
 
   private boolean hasPageOrAnnotationJavaScript(PDDocument document) throws IOException {

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
@@ -44,7 +44,7 @@ public class PDFDocumentDetector implements DocumentDetector {
 
   private boolean detectJavaScript(COSDictionary root) {
     COSDictionary names = root.getCOSDictionary(COSName.NAMES);
-    if (names != null && names.getCOSDictionary(COSName.getPDFName("JavaScript")) != null) {
+    if (names != null && names.getCOSDictionary(COSName.JAVA_SCRIPT) != null) {
       return true;
     }
     return root.getCOSDictionary(COSName.AA) != null;

--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/PDFDocumentDetector.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSArray;
 import org.apache.pdfbox.cos.COSBase;
 import org.apache.pdfbox.cos.COSDictionary;
 import org.apache.pdfbox.cos.COSName;
@@ -30,7 +31,7 @@ public class PDFDocumentDetector implements DocumentDetector {
           && !containsAcroForm(document)
           && !containsOpenAction(document);
     } catch (InvalidPasswordException e) {
-      Ivy.log().error("This file is encrypted and cannot be scanned for security threats before uploading.");
+      Ivy.log().error("This file is encrypted and cannot be scanned for security threats before uploading.", e);
       BpmError.create("portal:file:encrypted").throwError();
     } catch (Exception e) {
       Ivy.log().error("PDF security check failed", e);
@@ -104,7 +105,12 @@ public class PDFDocumentDetector implements DocumentDetector {
       return false;
     }
     COSDictionary treeNode = embeddedFilesTree.getCOSObject();
-    return treeNode.containsKey(COSName.NAMES) || treeNode.containsKey(COSName.KIDS);
+    return hasNonEmptyArray(treeNode, COSName.NAMES) || hasNonEmptyArray(treeNode, COSName.KIDS);
+  }
+
+  private boolean hasNonEmptyArray(COSDictionary dictionary, COSName key) {
+    COSBase value = dictionary.getDictionaryObject(key);
+    return value instanceof COSArray && ((COSArray) value).size() > 0;
   }
 
   private boolean containsAcroForm(PDDocument document) {
@@ -114,6 +120,7 @@ public class PDFDocumentDetector implements DocumentDetector {
 
   private boolean containsOpenAction(PDDocument document) {
     COSDictionary catalog = document.getDocumentCatalog().getCOSObject();
-    return catalog.getDictionaryObject(COSName.OPEN_ACTION) != null;
+    COSBase openAction = catalog.getDictionaryObject(COSName.OPEN_ACTION);
+    return openAction instanceof COSDictionary;
   }
 }


### PR DESCRIPTION
- Use PDFBox instead of itextpdf
- Improve PDF security check
   - Existing code, if the file PDF has permissions like cannot annotate in it, itextpdf cannot read the file and skip checking malicious stuff. It means the file has permissions and malicious stuff then Portal allows users to upload the file.
   - New implementation with PDFBox, it could read files have permission. Then it means the file has permissions and malicious stuff then Portal will block uploading the file.
