### PR TITLE
IVYPORTAL-20498 Stored XSS in creating External Page widget

### DIFF
--- a/AxonIvyPortal/portal/cms/cms.yaml
+++ b/AxonIvyPortal/portal/cms/cms.yaml
@@ -615,6 +615,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     columnManagement: Column management
     configuration:
       CustomWidgetExternalLinkWarning: Some websites are not compatible with iframe due to security concerns. Please contact your administrator if the external website is not working properly.
+      CustomWidgetUrlInvalidScheme: 'URL must start with http://, https://, or /'
       Parameters: Parameters
       SelectYourTemplate: Select your template
       configuration: Configuration

--- a/AxonIvyPortal/portal/cms/cms.yaml
+++ b/AxonIvyPortal/portal/cms/cms.yaml
@@ -615,7 +615,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     columnManagement: Column management
     configuration:
       CustomWidgetExternalLinkWarning: Some websites are not compatible with iframe due to security concerns. Please contact your administrator if the external website is not working properly.
-      CustomWidgetUrlInvalidScheme: 'URL must start with http://, https://, or /'
+      CustomWidgetUrlInvalidScheme: The provided URL is not valid
       Parameters: Parameters
       SelectYourTemplate: Select your template
       configuration: Configuration

--- a/AxonIvyPortal/portal/cms/cms_de.yaml
+++ b/AxonIvyPortal/portal/cms/cms_de.yaml
@@ -840,7 +840,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Standard-Feld
     configuration:
       CustomWidgetExternalLinkWarning: Einige Websites sind aufgrund von Sicherheitsbedenken nicht mit iframe kompatibel. Bitte wenden Sie sich an Ihren Administrator, wenn die externe Website nicht ordnungsgemäß funktioniert.
-      CustomWidgetUrlInvalidScheme: 'Die URL muss mit http://, https:// oder / beginnen'
+      CustomWidgetUrlInvalidScheme: Die angegebene URL ist ungültig
       CustomWidgetTitlePlaceholder: Lassen Sie es leer, um die Kopfzeile des Widgets auszublenden
       Parameters: Parameter
       RestoreDefaultDashboardTemplateTooltip: Wir können die Vorlage für Ihr Dashboard nicht finden und es daher nicht auf die Standardkonfiguration zurücksetzen. Bitte erkundigen Sie sich bei Ihrem Administrator nach weiteren Details!

--- a/AxonIvyPortal/portal/cms/cms_de.yaml
+++ b/AxonIvyPortal/portal/cms/cms_de.yaml
@@ -840,6 +840,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Standard-Feld
     configuration:
       CustomWidgetExternalLinkWarning: Einige Websites sind aufgrund von Sicherheitsbedenken nicht mit iframe kompatibel. Bitte wenden Sie sich an Ihren Administrator, wenn die externe Website nicht ordnungsgemäß funktioniert.
+      CustomWidgetUrlInvalidScheme: 'Die URL muss mit http://, https:// oder / beginnen'
       CustomWidgetTitlePlaceholder: Lassen Sie es leer, um die Kopfzeile des Widgets auszublenden
       Parameters: Parameter
       RestoreDefaultDashboardTemplateTooltip: Wir können die Vorlage für Ihr Dashboard nicht finden und es daher nicht auf die Standardkonfiguration zurücksetzen. Bitte erkundigen Sie sich bei Ihrem Administrator nach weiteren Details!

--- a/AxonIvyPortal/portal/cms/cms_en.yaml
+++ b/AxonIvyPortal/portal/cms/cms_en.yaml
@@ -838,7 +838,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Standard column
     configuration:
       CustomWidgetExternalLinkWarning: Some websites are not compatible with iframe due to security concerns. Please contact your administrator if the external website is not working properly.
-      CustomWidgetUrlInvalidScheme: 'URL must start with http://, https://, or /'
+      CustomWidgetUrlInvalidScheme: The provided URL is not valid
       CustomWidgetTitlePlaceholder: Leave it blank to hide the header of the widget
       Parameters: Parameters
       RestoreDefaultDashboardTemplateTooltip: We cannot find the template of your dashboard, so we cannot reset it to the standard configuration. Please check with your administrator for more details!

--- a/AxonIvyPortal/portal/cms/cms_en.yaml
+++ b/AxonIvyPortal/portal/cms/cms_en.yaml
@@ -838,6 +838,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Standard column
     configuration:
       CustomWidgetExternalLinkWarning: Some websites are not compatible with iframe due to security concerns. Please contact your administrator if the external website is not working properly.
+      CustomWidgetUrlInvalidScheme: 'URL must start with http://, https://, or /'
       CustomWidgetTitlePlaceholder: Leave it blank to hide the header of the widget
       Parameters: Parameters
       RestoreDefaultDashboardTemplateTooltip: We cannot find the template of your dashboard, so we cannot reset it to the standard configuration. Please check with your administrator for more details!

--- a/AxonIvyPortal/portal/cms/cms_es.yaml
+++ b/AxonIvyPortal/portal/cms/cms_es.yaml
@@ -840,6 +840,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Columna estándar
     configuration:
       CustomWidgetExternalLinkWarning: Algunas webs no son compatibles con iframe por motivos de seguridad. Póngase en contacto con su administrador si la web externa no funciona correctamente.
+      CustomWidgetUrlInvalidScheme: 'La URL debe comenzar con http://, https:// o /'
       CustomWidgetTitlePlaceholder: Déjalo en blanco para ocultar la cabecera del widget
       Parameters: Parámetros
       RestoreDefaultDashboardTemplateTooltip: No podemos encontrar la plantilla de su panel de control, por lo que no podemos restablecer la configuración estándar. Por favor, consulte con su administrador para obtener más detalles.

--- a/AxonIvyPortal/portal/cms/cms_es.yaml
+++ b/AxonIvyPortal/portal/cms/cms_es.yaml
@@ -840,7 +840,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Columna estándar
     configuration:
       CustomWidgetExternalLinkWarning: Algunas webs no son compatibles con iframe por motivos de seguridad. Póngase en contacto con su administrador si la web externa no funciona correctamente.
-      CustomWidgetUrlInvalidScheme: 'La URL debe comenzar con http://, https:// o /'
+      CustomWidgetUrlInvalidScheme: La URL proporcionada no es válida
       CustomWidgetTitlePlaceholder: Déjalo en blanco para ocultar la cabecera del widget
       Parameters: Parámetros
       RestoreDefaultDashboardTemplateTooltip: No podemos encontrar la plantilla de su panel de control, por lo que no podemos restablecer la configuración estándar. Por favor, consulte con su administrador para obtener más detalles.

--- a/AxonIvyPortal/portal/cms/cms_fr.yaml
+++ b/AxonIvyPortal/portal/cms/cms_fr.yaml
@@ -840,6 +840,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Colonne standard
     configuration:
       CustomWidgetExternalLinkWarning: Certains web sites ne sont pas compatibles avec les iframe pour des raisons de sécurité. Veuillez contacter votre administrateur si le web site externe ne fonctionne pas correctement.
+      CustomWidgetUrlInvalidScheme: 'L''URL doit commencer par http://, https:// ou /'
       CustomWidgetTitlePlaceholder: Laissez-le vide pour masquer l'en-tête du widget
       Parameters: Paramètres
       RestoreDefaultDashboardTemplateTooltip: Nous ne trouvons pas le modèle de votre tableau de bord, nous ne pouvons donc pas le réinitialiser à la configuration standard. Veuillez vérifier auprès de votre administrateur pour plus de détails!

--- a/AxonIvyPortal/portal/cms/cms_fr.yaml
+++ b/AxonIvyPortal/portal/cms/cms_fr.yaml
@@ -840,7 +840,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: Colonne standard
     configuration:
       CustomWidgetExternalLinkWarning: Certains web sites ne sont pas compatibles avec les iframe pour des raisons de sécurité. Veuillez contacter votre administrateur si le web site externe ne fonctionne pas correctement.
-      CustomWidgetUrlInvalidScheme: 'L''URL doit commencer par http://, https:// ou /'
+      CustomWidgetUrlInvalidScheme: L'URL fournie n'est pas valide
       CustomWidgetTitlePlaceholder: Laissez-le vide pour masquer l'en-tête du widget
       Parameters: Paramètres
       RestoreDefaultDashboardTemplateTooltip: Nous ne trouvons pas le modèle de votre tableau de bord, nous ne pouvons donc pas le réinitialiser à la configuration standard. Veuillez vérifier auprès de votre administrateur pour plus de détails!

--- a/AxonIvyPortal/portal/cms/cms_ja.yaml
+++ b/AxonIvyPortal/portal/cms/cms_ja.yaml
@@ -839,6 +839,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: 標準の列
     configuration:
       CustomWidgetExternalLinkWarning: 一部のウェブサイトは、セキュリティ上の懸念から iframe と互換性がありません。外部ウェブサイトが正常に動作しない場合は、管理者にお問い合わせください。
+      CustomWidgetUrlInvalidScheme: 'URL は http://、https://、または / で始まる必要があります'
       CustomWidgetTitlePlaceholder: ウィジェットのヘッダーを非表示にするには、空白のままにしてください
       Parameters: パラメーター
       RestoreDefaultDashboardTemplateTooltip: ダッシュボードのテンプレートが見つからないため、標準設定にリセットできません。詳細については管理者に確認してください。

--- a/AxonIvyPortal/portal/cms/cms_ja.yaml
+++ b/AxonIvyPortal/portal/cms/cms_ja.yaml
@@ -839,7 +839,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       STANDARD: 標準の列
     configuration:
       CustomWidgetExternalLinkWarning: 一部のウェブサイトは、セキュリティ上の懸念から iframe と互換性がありません。外部ウェブサイトが正常に動作しない場合は、管理者にお問い合わせください。
-      CustomWidgetUrlInvalidScheme: 'URL は http://、https://、または / で始まる必要があります'
+      CustomWidgetUrlInvalidScheme: 指定された URL は無効です
       CustomWidgetTitlePlaceholder: ウィジェットのヘッダーを非表示にするには、空白のままにしてください
       Parameters: パラメーター
       RestoreDefaultDashboardTemplateTooltip: ダッシュボードのテンプレートが見つからないため、標準設定にリセットできません。詳細については管理者に確認してください。

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardCustomWidgetBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardCustomWidgetBean.java
@@ -5,8 +5,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.List;
 
+import javax.faces.application.FacesMessage;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
+import javax.faces.component.UIComponent;
+import javax.faces.context.FacesContext;
+import javax.faces.validator.ValidatorException;
 
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -14,6 +18,8 @@ import com.axonivy.portal.components.service.impl.ProcessService;
 
 import ch.ivy.addon.portalkit.dto.dashboard.CustomDashboardWidgetParam;
 import ch.ivy.addon.portalkit.enums.DashboardCustomWidgetType;
+import ch.ivy.addon.portalkit.util.UrlUtils;
+import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 @ManagedBean
@@ -52,8 +58,24 @@ public class DashboardCustomWidgetBean implements Serializable {
     }
     return allCustomDashboardProcesses;
   }
-  
+
   public String encodeValue(String value) throws UnsupportedEncodingException {
     return URLEncoder.encode(value, "UTF-8");
+  }
+
+  public String safeUrlOrEmpty(String url) {
+    return UrlUtils.isSafeIframeUrl(url) ? url : "";
+  }
+
+  public void validateUrl(FacesContext context, UIComponent component, Object value) {
+    if (value == null) {
+      return;
+    }
+    String url = String.valueOf(value);
+    if (!UrlUtils.isSafeIframeUrl(url)) {
+      String message = Ivy.cms()
+          .co("/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/CustomWidgetUrlInvalidScheme");
+      throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR, message, null));
+    }
   }
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardCustomWidgetBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/DashboardCustomWidgetBean.java
@@ -64,7 +64,8 @@ public class DashboardCustomWidgetBean implements Serializable {
   }
 
   public String safeUrlOrEmpty(String url) {
-    return UrlUtils.isSafeIframeUrl(url) ? url : "";
+    String trimmed = url == null ? null : url.trim();
+    return UrlUtils.isSafeIframeUrl(trimmed) ? trimmed : "";
   }
 
   public void validateUrl(FacesContext context, UIComponent component, Object value) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/widget/DashboardCustomWidgetData.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/widget/DashboardCustomWidgetData.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import ch.ivy.addon.portalkit.dto.dashboard.CustomDashboardWidgetParam;
 import ch.ivy.addon.portalkit.enums.DashboardCustomWidgetType;
+import ch.ivy.addon.portalkit.util.UrlUtils;
 import ch.ivyteam.ivy.workflow.start.IWebStartable;
 import ch.ivyteam.ivy.workflow.start.StartParameter;
 
@@ -35,7 +36,7 @@ public class DashboardCustomWidgetData implements Serializable {
   }
 
   public void setUrl(String url) {
-    this.url = url;
+    this.url = UrlUtils.isSafeIframeUrl(url) ? url : "";
   }
 
   public String getProcessPath() {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/widget/DashboardCustomWidgetData.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/widget/DashboardCustomWidgetData.java
@@ -36,7 +36,8 @@ public class DashboardCustomWidgetData implements Serializable {
   }
 
   public void setUrl(String url) {
-    this.url = UrlUtils.isSafeIframeUrl(url) ? url : "";
+    String trimmed = url == null ? null : url.trim();
+    this.url = UrlUtils.isSafeIframeUrl(trimmed) ? trimmed : "";
   }
 
   public String getProcessPath() {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UrlUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UrlUtils.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -63,7 +64,7 @@ public class UrlUtils {
     if (StringUtils.isBlank(url)) {
       return true;
     }
-    String trimmed = url.trim().toLowerCase();
+    String trimmed = url.trim().toLowerCase(Locale.ROOT);
     if (trimmed.startsWith("//")) {
       return false;
     }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UrlUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/UrlUtils.java
@@ -59,6 +59,19 @@ public class UrlUtils {
         || urlInLowerCase.startsWith("/");
   }
 
+  public static boolean isSafeIframeUrl(String url) {
+    if (StringUtils.isBlank(url)) {
+      return true;
+    }
+    String trimmed = url.trim().toLowerCase();
+    if (trimmed.startsWith("//")) {
+      return false;
+    }
+    return trimmed.startsWith(Protocol.HTTP.getValue())
+        || trimmed.startsWith(Protocol.HTTPS.getValue())
+        || trimmed.startsWith("/");
+  }
+
   public static String formatLinkWithEmbedInFrameParam(String link) {
     if (StringUtils.isBlank(link) || link.contains(EMBED_IN_FRAME)) {
       return link;

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomDashboardWidget/CustomDashboardWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomDashboardWidget/CustomDashboardWidget.xhtml
@@ -71,7 +71,7 @@
           </h:panelGroup>
         </ui:fragment>
 
-        <ui:fragment rendered="#{empty widget.data.processPath}">
+        <ui:fragment rendered="#{empty widget.data.processPath and not empty dashboardCustomWidgetBean.safeUrlOrEmpty(widget.data.url)}">
           <iframe name="custom-widget-iframe-#{index}" src="#{dashboardCustomWidgetBean.safeUrlOrEmpty(widget.data.url)}"
             id="id-custom-widget-iframe-#{index}"
             class="dashboard-custom-iframe hidden"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomDashboardWidget/CustomDashboardWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomDashboardWidget/CustomDashboardWidget.xhtml
@@ -72,9 +72,9 @@
         </ui:fragment>
 
         <ui:fragment rendered="#{empty widget.data.processPath}">
-          <iframe name="custom-widget-iframe-#{index}" src="#{widget.data.url}"
+          <iframe name="custom-widget-iframe-#{index}" src="#{dashboardCustomWidgetBean.safeUrlOrEmpty(widget.data.url)}"
             id="id-custom-widget-iframe-#{index}"
-            class="dashboard-custom-iframe hidden" 
+            class="dashboard-custom-iframe hidden"
             title="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portal/generic/dashboard/component/CustomDashboardWidget/CustomWidgetIFrameTitle', [widget.name])}" />
           <script type="text/javascript">
               setTimeout(function(){

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomWidgetConfiguration/CustomWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomWidgetConfiguration/CustomWidgetConfiguration.xhtml
@@ -74,7 +74,8 @@
       </div>
       <div class="ui-g-8 ui-fluid">
         <p:inputText id="external-url" value="#{widget.data.url}"
-          required="#{!isIvyProcess and param['skipValidator'] == null}" />
+          required="#{!isIvyProcess and param['skipValidator'] == null}"
+          validator="#{dashboardCustomWidgetBean.validateUrl}" />
       </div>
       <div class="ui-g-12">
         <h:outputText

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CustomIFrameWidget/CustomIFrameWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CustomIFrameWidget/CustomIFrameWidget.xhtml
@@ -18,7 +18,7 @@
   <h:panelGroup id="custom-iframe" rendered="#{(widget.type eq 'custom') and (not empty widget.data.url)}"
     styleClass="card custom-widget-card #{cc.attrs.widgetStyleClass} grid-stack-item-content #{managedBean.readOnlyMode ? '' : 'moveable-area'} iframe-widget">
     <ui:fragment rendered="#{not empty widget.data.processPath}">
-      <form id="#{cc.clientId}:custom-widget-iframe-data" target="#{cc.clientId}:custom-widget-iframe" action="#{widget.data.url}" method="post">
+      <form id="#{cc.clientId}:custom-widget-iframe-data" target="#{cc.clientId}:custom-widget-iframe" action="#{dashboardCustomWidgetBean.safeUrlOrEmpty(widget.data.url)}" method="post">
         <ui:repeat var="entry" value="#{widget.data.params.entrySet()}">
           <input type="hidden" name="#{entry.key}"
             value="#{managedBean.getPropertyByKeyPattern(referenceId, entry.value)}" />
@@ -33,7 +33,7 @@
        </script>
     </ui:fragment>
     <ui:fragment rendered="#{empty widget.data.processPath}">
-      <iframe name="custom-widget-iframe-url" src="#{widget.data.url}"
+      <iframe name="custom-widget-iframe-url" src="#{dashboardCustomWidgetBean.safeUrlOrEmpty(widget.data.url)}"
       title="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portalkit/component/CustomIFrameWidget/CustomWidgetIFrameTitle')}" />
     </ui:fragment>
   </h:panelGroup>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CustomIFrameWidget/CustomIFrameWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CustomIFrameWidget/CustomIFrameWidget.xhtml
@@ -15,7 +15,7 @@
   <c:set var="referenceId" value="#{cc.attrs.referenceId}" />
   <c:set var="managedBean" value="#{cc.attrs.managedBean}" />
 
-  <h:panelGroup id="custom-iframe" rendered="#{(widget.type eq 'custom') and (not empty widget.data.url)}"
+  <h:panelGroup id="custom-iframe" rendered="#{(widget.type eq 'custom') and (not empty dashboardCustomWidgetBean.safeUrlOrEmpty(widget.data.url))}"
     styleClass="card custom-widget-card #{cc.attrs.widgetStyleClass} grid-stack-item-content #{managedBean.readOnlyMode ? '' : 'moveable-area'} iframe-widget">
     <ui:fragment rendered="#{not empty widget.data.processPath}">
       <form id="#{cc.clientId}:custom-widget-iframe-data" target="#{cc.clientId}:custom-widget-iframe" action="#{dashboardCustomWidgetBean.safeUrlOrEmpty(widget.data.url)}" method="post">

--- a/Documentation/portal-guide/source/portal-developer-guide/installation/index.rst
+++ b/Documentation/portal-guide/source/portal-developer-guide/installation/index.rst
@@ -508,9 +508,6 @@ Changes in 12.0.11
 
 - Enhanced the document preview feature for the task and case detail. If you have :dev-url:`DocFactory <https://market.axonivy.com/doc-factory#tab-description>` in the same security context, you can preview Word(doc, docx), Excel(xls, xlsx) and email(eml) documents.
 - Enhanced the **Document Table** component by adding the lazy loading functionality to the Document Table component, enabling efficient data loading through pagination.
-- Custom dashboard widget (External Page) URLs are now restricted to ``http://``, ``https://``, and relative paths starting with ``/``.
-  Existing widgets configured with other schemes (e.g. ``javascript:``, ``data:``, ``ftp:``) will render as blank iframes after upgrade.
-  Review your persisted ``Portal.Dashboard`` Ivy variable and reconfigure any affected widgets through the dashboard editor.
 
 Changes in 12.0.9
 -----------------

--- a/Documentation/portal-guide/source/portal-developer-guide/installation/index.rst
+++ b/Documentation/portal-guide/source/portal-developer-guide/installation/index.rst
@@ -508,6 +508,9 @@ Changes in 12.0.11
 
 - Enhanced the document preview feature for the task and case detail. If you have :dev-url:`DocFactory <https://market.axonivy.com/doc-factory#tab-description>` in the same security context, you can preview Word(doc, docx), Excel(xls, xlsx) and email(eml) documents.
 - Enhanced the **Document Table** component by adding the lazy loading functionality to the Document Table component, enabling efficient data loading through pagination.
+- Custom dashboard widget (External Page) URLs are now restricted to ``http://``, ``https://``, and relative paths starting with ``/``.
+  Existing widgets configured with other schemes (e.g. ``javascript:``, ``data:``, ``ftp:``) will render as blank iframes after upgrade.
+  Review your persisted ``Portal.Dashboard`` Ivy variable and reconfigure any affected widgets through the dashboard editor.
 
 Changes in 12.0.9
 -----------------


### PR DESCRIPTION
- Added a new method isSafeIframeUrl() that only allows URLs starting with http://, https://, or / (relative paths). Everything else — javascript:, data:, vbscript:, protocol-relative //, etc. — is rejected.

- The setUrl() method now silently clears unsafe URLs to an empty string. This protects against any path that bypasses the form validator — such as dashboard import from a JSON file.

- Added the user-facing error message: "URL must start with http://, https://, or /"

- Added a note warning that existing widgets with non-standard URL schemes will render as blank after upgrading, and instructing admins to review the Portal.Dashboard Ivy variable.