### PR TITLE
IVYPORTAL-20276 fix test selectors missed in icon migration

### DIFF
--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/MainMenuPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/MainMenuPage.java
@@ -193,14 +193,14 @@ public class MainMenuPage extends TemplatePage {
   public void isSidebarClickModeCollapsed() {
     $(".js-layout-wrapper.sidebar-click-mode").should(Condition.exist, DEFAULT_TIMEOUT);
     $(".js-sidebar-toggle-btn").shouldHave(Condition.attribute("aria-expanded", "false"), DEFAULT_TIMEOUT);
-    $(".js-sidebar-toggle-icon").shouldHave(Condition.cssClass("ti-layout-sidebar-left-collapse"), DEFAULT_TIMEOUT);
+    $(".js-sidebar-toggle-icon").shouldHave(Condition.cssClass("ti-layout-sidebar-left-expand"), DEFAULT_TIMEOUT);
     $(".js-layout-wrapper").shouldNotHave(Condition.cssClass("layout-static"));
   }
 
   public void isSidebarClickModeExpanded() {
     $(".js-layout-wrapper.sidebar-click-mode").should(Condition.exist, DEFAULT_TIMEOUT);
     $(".js-sidebar-toggle-btn").shouldHave(Condition.attribute("aria-expanded", "true"), DEFAULT_TIMEOUT);
-    $(".js-sidebar-toggle-icon").shouldHave(Condition.cssClass("ti-layout-sidebar-left-expand"), DEFAULT_TIMEOUT);
+    $(".js-sidebar-toggle-icon").shouldHave(Condition.cssClass("ti-layout-sidebar-left-collapse"), DEFAULT_TIMEOUT);
     $(".js-layout-wrapper").shouldHave(Condition.cssClass("layout-static"));
   }
 

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/ProcessWidgetPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/ProcessWidgetPage.java
@@ -110,7 +110,7 @@ public class ProcessWidgetPage extends TemplatePage {
 
     $("input[id$=':search-icon-name-field']").sendKeys(iconClass);
 
-    $("div[id='process-widget:add-external-link-form:external-link-icon:icons-selection-form:icons']")
+    $("div[id='process-widget:add-external-link-form:external-link-icon:icons-selection-form:tabler-icons']")
         .$("a[title='" + iconClass + "']").click();
     $("div[id$='process-widget:add-external-link-form:external-link-icon:select-icon-dialog']")
         .shouldBe(Condition.disappear, DEFAULT_TIMEOUT);


### PR DESCRIPTION
- ProcessWidgetPage.addExternalLink: target tabler-icons panel (replaces removed `icons` panel) so ExternalLinkTest can locate Tabler icons.
- MainMenuPage.isSidebarClickMode{Collapsed,Expanded}: assert the icon class matching the action the icon offers, aligning with sidebar.js semantics after the Tabler rename.