### PR TITLE
IVYPORTAL-20566 Stored XSS in case description via HTML entity round-trip

### DIFF
--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/ProcessHistory/ProcessHistory.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/ProcessHistory/ProcessHistory.xhtml
@@ -83,7 +83,7 @@
               <h:panelGroup rendered="#{processHistoryComponentBean.dataModel.isSelectedColumn('NAME')}">
                 <h:outputText id="case-header-name-cell" styleClass="case-header-name-cell"
                   value="#{empty case.names().current() ? ivy.cms.co('/Dialogs/com/axonivy/portal/components/ProcessHistory/CaseNameNotAvailable') : case.names().current()}" />
-                <h:outputText escape="false" value="#{processHistoryComponentBean.formatCaseDescription(case.descriptions().current())}" id="description-cell" styleClass="case-header-desc-cell" />
+                <h:outputText value="#{processHistoryComponentBean.formatCaseDescription(case.descriptions().current())}" id="description-cell" styleClass="case-header-desc-cell" />
               </h:panelGroup>
             </h:panelGroup>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemRelatedCases/CaseItemRelatedCases.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemRelatedCases/CaseItemRelatedCases.xhtml
@@ -59,7 +59,7 @@
         
         <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/description')}" sortable="false" styleClass="description-column u-truncate-text"
           visible="#{caseDetailsBean.isDisplayColumn(data.caseLazyDataModel, 'NAME')}" >
-          <h:outputText id="case-description" escape="false" value="#{caseDescription}" title="#{caseDescription}"/>
+          <h:outputText id="case-description" value="#{caseDescription}" title="#{caseDescription}"/>
           <p:tooltip for="case-description" value="#{caseDescription}" trackMouse="true" hideEvent="mouseleave click"/>
         </p:column>
         

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/cases/column/CaseName/CaseName.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/cases/column/CaseName/CaseName.xhtml
@@ -20,7 +20,7 @@
   <h:panelGroup rendered="#{cc.attrs.dataModel.isSelectedColumn('NAME')}">
     <h:outputText id="#{cc.attrs.caseNameId}" styleClass="case-header-name-cell #{cc.attrs.nameStyleClass} #{cc.attrs.responsiveStyleClass}" value="#{caseName}" />
     <p:tooltip for="#{cc.attrs.caseNameId}" value="#{caseName}" trackMouse="true" hideEvent="mouseleave click" />
-    <h:outputText id="#{cc.attrs.caseDescriptionId}" styleClass="case-header-desc-cell" escape="false" value="#{caseDescription}" />
+    <h:outputText id="#{cc.attrs.caseDescriptionId}" styleClass="case-header-desc-cell" value="#{caseDescription}" />
     <p:tooltip for="#{cc.attrs.caseDescriptionId}" value="#{caseDescription}" trackMouse="true" hideEvent="mouseleave click"/>
   </h:panelGroup>
 </cc:implementation>


### PR DESCRIPTION
- formatCaseDescription strips HTML tags via Jsoup body().text(), but the same call decodes HTML entities. The three list-like sinks (case-list, related-cases, process-history) paired that decoded string with escape="false", so entity-encoded payloads reached the browser as live HTML.

- Drop escape="false" on those sinks; JSF default escaping re-encodes any decoded characters before render. Aligns the three list-like surfaces with IVYPORTAL-14874 (HTML hidden in lists, kept only in Case/Task detail views). Detail-view descriptions go through sanitizeHTML and are unchanged.