### PR TITLE
IVYPORTAL-20376 Open redirect via unvalidated External Link URL scheme

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ExternalLinkBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/ExternalLinkBean.java
@@ -32,6 +32,7 @@ import ch.ivy.addon.portalkit.service.ExternalLinkService;
 import ch.ivy.addon.portalkit.util.DisplayNameConvertor;
 import ch.ivy.addon.portalkit.util.LanguageUtils;
 import ch.ivy.addon.portalkit.util.PermissionUtils;
+import ch.ivy.addon.portalkit.util.UrlUtils;
 import ch.ivy.addon.portalkit.util.UserUtils;
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.security.IUser;
@@ -116,7 +117,12 @@ public class ExternalLinkBean implements Serializable, IMultiLanguage {
   }
   
   public void startExternalLink(ExternalLink selectedExternalLink) throws IOException {
-    FacesContext.getCurrentInstance().getExternalContext().redirect(selectedExternalLink.getLink());
+    String link = selectedExternalLink == null ? null : selectedExternalLink.getLink();
+    if (!UrlUtils.isSafeIframeUrl(link)) {
+      Ivy.log().warn("Blocked external link redirect with unsafe URL: {0}", link);
+      return;
+    }
+    FacesContext.getCurrentInstance().getExternalContext().redirect(link);
   }
 
   public ExternalLink getExternalLink() {


### PR DESCRIPTION
- `ExternalLinkBean.startExternalLink()` redirected to the stored `ExternalLink.getLink()` value without scheme validation. The JSF AJAX `<partial-response>` redirect path emits `<redirect url="..."/>` which modern browsers act on as `window.location = ...` — so a stored `javascript:alert(document.domain)` URL executes JS in the viewer's origin (same family as SUPPORT-1871). Protocol-relative `//attacker` URLs also leave the Portal origin entirely.

- Gate the redirect with `UrlUtils.isSafeIframeUrl(...)` (introduced by IVYPORTAL-20498) so only `http(s)://` and same-origin relative paths pass; log + drop the request otherwise. The validator already lives in the codebase for the Custom widget iframe; reusing it keeps the allow-list policy in one place.