### PR TITLE
IVYPORTAL-20514 Dashboard processes can't be found

### DIFF
--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/ProcessViewerUtils.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/util/ProcessViewerUtils.java
@@ -1,12 +1,10 @@
 package com.axonivy.portal.components.util;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Predicate;
 
-import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 
@@ -28,16 +26,17 @@ import ch.ivyteam.ivy.workflow.start.IWebStartable;
 
 public class ProcessViewerUtils {
 
-  private static List<IWebStartable> webStartables;
-
   public static ProcessViewerDTO initProcessViewer(Long taskId, Long caseId, String processLink) {
-    boolean isViewerAllowed = false;
+    // change from primitive type boolean isViewerAllowed = false
+    // reason: it makes bug when not found process will be considered as no permission
+    Boolean isViewerAllowed = null;
     IWebStartable webStartable = null;
     WebLink webLink = null;
     boolean isError = false;
     String errorIcon = "";
     String errorMessage = null;
     if (taskId != 0 || caseId != 0 || StringUtils.isNotBlank(processLink)) {
+      List<IWebStartable> startables = getWebStartables();
       // init data using caseId
       ITask selectedTask = TaskUtils.findTaskById(taskId);
       isViewerAllowed = isViewerAllowed(selectedTask);
@@ -45,9 +44,9 @@ public class ProcessViewerUtils {
         webLink = ProcessViewer.of(selectedTask).url().toWebLink();
         ICaseMap caseMap = findCaseMapByCase(selectedTask.getCase());
         if (!Objects.isNull(caseMap)) {
-          webStartable = findWebStartable(caseMap);
+          webStartable = findWebStartableForCaseMap(startables, caseMap);
         } else {
-          webStartable = findWebStartable(selectedTask.getCase().getProcessStart().getLink().getRelative());
+          webStartable = findWebStartableForProcessLink(startables, selectedTask.getCase().getProcessStart().getLink().getRelative());
         }
       } else {
         ICase selectedCase = CaseUtils.findCase(caseId);
@@ -55,10 +54,10 @@ public class ProcessViewerUtils {
         if (isViewerAllowed) {
           ICaseMap caseMap = findCaseMapByCase(selectedCase);
           if (!Objects.isNull(caseMap)) {
-            webStartable = findWebStartable(caseMap);
+            webStartable = findWebStartableForCaseMap(startables, caseMap);
             webLink = CaseMapViewer.of(caseMap).url().toWebLink();
           } else {
-            webStartable = findWebStartable(selectedCase.getProcessStart().getLink().getRelative());
+            webStartable = findWebStartableForProcessLink(startables, selectedCase.getProcessStart().getLink().getRelative());
             webLink = ProcessViewer.of(selectedCase).url().toWebLink();
           }
         }
@@ -67,13 +66,15 @@ public class ProcessViewerUtils {
       // try to init data using processLink
       if (webLink == null) {
         errorIcon = "ti ti-alert-circle";
-        webStartable = findWebStartable(processLink);
-        isViewerAllowed = isViewerAllowed(webStartable);
-        if (isViewerAllowed) {
-          if (webStartable instanceof ICaseMapWebStartable) {
-            webLink = CaseMapViewer.of((ICaseMapWebStartable) webStartable).url().toWebLink();
-          } else {
-            webLink = ProcessViewer.of((IProcessWebStartable) webStartable).url().toWebLink();
+        webStartable = findWebStartableForProcessLink(startables, processLink);
+        if (webStartable != null) {
+          isViewerAllowed = isViewerAllowed(webStartable);
+          if (isViewerAllowed) {
+            if (webStartable instanceof ICaseMapWebStartable) {
+              webLink = CaseMapViewer.of((ICaseMapWebStartable) webStartable).url().toWebLink();
+            } else {
+              webLink = ProcessViewer.of((IProcessWebStartable) webStartable).url().toWebLink();
+            }
           }
         }
       }
@@ -82,7 +83,7 @@ public class ProcessViewerUtils {
     // check result
     if (webLink == null) {
       isError = true;
-      if (!isViewerAllowed) {
+      if (BooleanUtils.isFalse(isViewerAllowed)) {
         errorIcon = "ti ti-lock";
         errorMessage = Ivy.cms().co("/Dialogs/com/axonivy/portal/components/ProcessViewer/NoPermissionToView");
       } else {
@@ -101,10 +102,18 @@ public class ProcessViewerUtils {
         .build();
   }
 
-  public static IWebStartable findWebStartable(ICaseMap caseMap) {
+  private static IWebStartable findWebStartableForCaseMap(List<IWebStartable> startables, ICaseMap caseMap) {
     if (caseMap != null) {
-      return getWebStartables().stream().filter(filterById(caseMap.getUuid().toString())).findFirst().orElse(null);
+      return startables.stream().filter(filterById(caseMap.getUuid().toString())).findFirst().orElse(null);
     }
+    return null;
+  }
+
+  private static IWebStartable findWebStartableForProcessLink(List<IWebStartable> startables, String processLink) {
+    if (StringUtils.isNotBlank(processLink)) {
+      return startables.stream().filter(filterByRelativeLink(processLink)).findFirst().orElse(null);
+    }
+
     return null;
   }
 
@@ -112,7 +121,7 @@ public class ProcessViewerUtils {
     if (StringUtils.isNotBlank(processLink)) {
       return getWebStartables().stream().filter(filterByRelativeLink(processLink)).findFirst().orElse(null);
     }
-    
+
     return null;
   }
 
@@ -125,10 +134,7 @@ public class ProcessViewerUtils {
   }
 
   private static List<IWebStartable> getWebStartables() {
-    if (CollectionUtils.isEmpty(webStartables)) {
-      webStartables = ProcessService.getInstance().findProcesses();
-    }
-    return Optional.ofNullable(webStartables).orElse(new ArrayList<>());
+    return ProcessService.getInstance().findProcesses();
   }
 
   public static ICaseMap findCaseMapByCase(ICase caze) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/CustomWidgetUtils.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/util/CustomWidgetUtils.java
@@ -6,7 +6,6 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -34,9 +33,6 @@ public class CustomWidgetUtils {
   public static final String CUSTOM_FIELD_PREFIX = "customFields";
   public static final String USER_PREFIX = "user";
   public static final String PROPERTY_PREFIX = "property";
-
-  public static List<IWebStartable> allPortalProcesses;
-  public static List<IWebStartable> allCustomDashboardProcesses;
 
   public static String getPropertyByKeyPattern(Long referenceId , String keyPattern) {
     String propertyValue = keyPattern;
@@ -181,13 +177,6 @@ public class CustomWidgetUtils {
         customWidget.setErrorMessage(Ivy.cms().co("/Dialogs/com/axonivy/portal/components/ProcessViewer/ProcessNotFound"));
         customWidget.setErrorIcon("ti ti-alert-circle");
         return;
-      } 
-      boolean isViewerAllowed = Ivy.session().getAllStartables().anyMatch(item-> item.getId().equals(startable.getId()));
-      if (!isViewerAllowed) {
-        customWidget.getData().setStartRequestPath(EMPTY);
-        customWidget.setErrorIcon("ti ti-lock");
-        customWidget.setErrorMessage(Ivy.cms().co("/Dialogs/com/axonivy/portal/components/ProcessViewer/NoPermissionToView"));
-        return;
       }
       customWidget.getData().setStartableProcessStart(startable);
       customWidget.loadParameters();
@@ -208,7 +197,7 @@ public class CustomWidgetUtils {
     }
   }
 
-  public static IWebStartable findWebStartableByProcessPath(String processPath) {
+  private static IWebStartable findWebStartableByProcessPath(String processPath) {
     // Find IWebStartable by ProcessID first
     // If not found, try to find by IWebStartable by friendly request path then find IWebStartable by link
     IWebStartable webStartable = getAllPortalProcesses().stream()
@@ -224,29 +213,25 @@ public class CustomWidgetUtils {
   }
 
   public static IWebStartable findStartableOfCustomDashboardProcess(String processPath) {
-    IWebStartable startable = getAllCustomDashboardProcesses().stream()
-        .filter(proccess -> processPath.endsWith(proccess.getId()))
+    List<IWebStartable> allCustomDashboardProcesses = getAllCustomDashboardProcesses();
+
+    IWebStartable startable = allCustomDashboardProcesses.stream()
+        .filter(process -> processPath.endsWith(process.getId()))
         .findAny().orElse(null);
     if (isNull(startable)) {
       String processStartLink = ProcessStartAPI.findRelativeUrlByProcessStartFriendlyRequestPath(processPath);
-      startable = getAllCustomDashboardProcesses().stream()
+      startable = allCustomDashboardProcesses.stream()
           .filter(proccess -> proccess.getLink().getRelative().equals(processStartLink))
           .findAny().orElse(null);
     }
     return startable;
   }
-  
+
   private static List<IWebStartable> getAllPortalProcesses() {
-    if (CollectionUtils.isEmpty(allPortalProcesses)) {
-      allPortalProcesses = ProcessService.getInstance().findProcesses();
-    }
-    return allPortalProcesses;
+    return ProcessService.getInstance().findProcesses();
   }
 
   public static List<IWebStartable> getAllCustomDashboardProcesses() {
-    if (CollectionUtils.isEmpty(allCustomDashboardProcesses)) {
-      allCustomDashboardProcesses = ProcessService.getInstance().findCustomDashboardProcesses();
-    }
-    return allCustomDashboardProcesses;
+    return ProcessService.getInstance().findCustomDashboardProcesses();
   }
 }

--- a/Showcase/InternalSupport/processes/Business Processes/testProcesses/BusinessCases.p.json
+++ b/Showcase/InternalSupport/processes/Business Processes/testProcesses/BusinessCases.p.json
@@ -80,7 +80,7 @@
           "code" : [
             "import ch.ivyteam.ivy.process.model.value.SignalCode;",
             "",
-            "SignalCode code = new SignalCode(\"com:axonivy:portal:internalsupport:updateCheckInTime\");",
+            "SignalCode code = SignalCode.of(\"com:axonivy:portal:internalsupport:updateCheckInTime\");",
             "ivy.wf.signals().send(code);"
           ]
         }
@@ -281,7 +281,7 @@
           "code" : [
             "import ch.ivyteam.ivy.process.model.value.SignalCode;",
             "",
-            "SignalCode code = new SignalCode(\"com:axonivy:portal:internalsupport:pizzaDelivery\");",
+            "SignalCode code = SignalCode.of(\"com:axonivy:portal:internalsupport:pizzaDelivery\");",
             "ivy.wf.signals().send(code);"
           ]
         }
@@ -363,7 +363,7 @@
           "code" : [
             "import ch.ivyteam.ivy.process.model.value.SignalCode;",
             "",
-            "SignalCode code = new SignalCode(\"com:axonivy:portal:internalsupport:informSale\");",
+            "SignalCode code = SignalCode.of(\"com:axonivy:portal:internalsupport:informSale\");",
             "ivy.wf.signals().send(code);"
           ]
         }

--- a/Showcase/portal-components-examples/processes/Start Processes/ProcessHistoryExample.p.json
+++ b/Showcase/portal-components-examples/processes/Start Processes/ProcessHistoryExample.p.json
@@ -235,7 +235,7 @@
           "code" : [
             "import ch.ivyteam.ivy.process.model.value.SignalCode;",
             "",
-            "SignalCode code = new SignalCode(\"com:axonivy:portal:portalcomponentsexamples:createBetaCompany\");",
+            "SignalCode code = SignalCode.of(\"com:axonivy:portal:portalcomponentsexamples:createBetaCompany\");",
             "ivy.wf.signals().send(code);"
           ]
         }

--- a/Showcase/portal-developer-examples/processes/Start Processes/CreateTestData.p.json
+++ b/Showcase/portal-developer-examples/processes/Start Processes/CreateTestData.p.json
@@ -104,7 +104,7 @@
                 "",
                 "ivy.case.setCategoryPath(\"Technical Task\");",
                 "",
-                "SignalCode code = new SignalCode(\"com:axonivy:portal:portaldeveloperexamples:createTaskFailed\");",
+                "SignalCode code = SignalCode.of(\"com:axonivy:portal:portaldeveloperexamples:createTaskFailed\");",
                 "ivy.wf.signals().send(code);"
               ]
             },
@@ -198,7 +198,7 @@
               "code" : [
                 "import ch.ivyteam.ivy.process.model.value.SignalCode;",
                 "",
-                "SignalCode code = new SignalCode(\"com:axonivy:portal:portaldeveloperexamples:createTechnicalTask\");",
+                "SignalCode code = SignalCode.of(\"com:axonivy:portal:portaldeveloperexamples:createTechnicalTask\");",
                 "ivy.wf.signals().send(code);"
               ]
             }
@@ -783,7 +783,7 @@
             "",
             "ivy.case.setCategoryPath(\"Payment\");",
             "",
-            "SignalCode code = new SignalCode(\"com:axonivy:portal:portaldeveloperexamples:createNewPayment\");",
+            "SignalCode code = SignalCode.of(\"com:axonivy:portal:portaldeveloperexamples:createNewPayment\");",
             "ivy.wf.signals().send(code);"
           ]
         },


### PR DESCRIPTION
## Summary
This PR refactors process viewer utility classes to improve code quality and fix permission checking logic. The main changes involve removing static caching of web startables, simplifying method signatures, and fixing a bug where missing processes were incorrectly treated as permission denials.

## Key Changes

### ProcessViewerUtils.java
- **Removed static caching**: Eliminated the `webStartables` static field and simplified `getWebStartables()` to directly call `ProcessService.getInstance().findProcesses()` without caching
- **Fixed permission checking bug**: Changed `isViewerAllowed` from primitive `boolean` to `Boolean` to distinguish between "not found" (null) and "no permission" (false) states
- **Refactored method signatures**: 
  - Split `findWebStartable()` into two specialized methods: `findWebStartableForCaseMap()` and `findWebStartableForProcessLink()` with explicit parameters
  - Made new methods private and passed `startables` list as parameter instead of relying on static field
- **Improved null safety**: Added explicit null check for `webStartable` before calling `isViewerAllowed()` in the processLink fallback path
- **Updated permission check**: Changed final permission validation from `!isViewerAllowed` to `BooleanUtils.isFalse(isViewerAllowed)` for clearer intent
- **Cleaned up imports**: Removed unused imports (`ArrayList`, `Optional`, `CollectionUtils`) and added `BooleanUtils`

### CustomWidgetUtils.java
- **Removed static caching**: Eliminated `allPortalProcesses` and `allCustomDashboardProcesses` static fields
- **Simplified methods**: Updated `getAllPortalProcesses()` and `getAllCustomDashboardProcesses()` to directly return service results without caching
- **Removed redundant permission check**: Deleted duplicate permission validation logic that was already handled elsewhere
- **Made method private**: Changed `findWebStartableByProcessPath()` visibility to private
- **Code cleanup**: Removed unused `CollectionUtils` import and fixed minor formatting issues

### Process JSON Files
- **Updated SignalCode instantiation**: Replaced deprecated `new SignalCode()` constructor with `SignalCode.of()` factory method across multiple process definition files

## Implementation Details
- The removal of static caching ensures fresh data is always retrieved from the service, improving reliability
- The Boolean wrapper type for `isViewerAllowed` prevents false negatives when processes cannot be found
- Method refactoring improves testability by allowing injection of the startables list

https://claude.ai/code/session_01YMadbotJpXctQUHxRmtgdL