### PR TITLE
Harden SVGSecurityScanner against SMIL and encoded-scheme bypasses

### DIFF
--- a/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/SVGSecurityScanner.java
+++ b/AxonIvyPortal/portal-components/src/com/axonivy/portal/components/document/SVGSecurityScanner.java
@@ -34,6 +34,17 @@ public class SVGSecurityScanner implements DocumentDetector {
 
   private static final Set<String> HREF_ATTRS = Set.of("href", "xlink:href");
 
+  // SMIL animation elements can dynamically (re)assign attributes at runtime - e.g. set the
+  // parent's xlink:href to a javascript: URL, or define an on* handler - while hiding the target
+  // attribute behind attributeName=. They are rejected when they animate a dangerous attribute.
+  private static final Set<String> SMIL_ANIMATION_ELEMENTS =
+      Set.of("set", "animate", "animatetransform", "animatemotion");
+
+  // Percent-encoded ASCII control/whitespace bytes (e.g. %09 TAB, %0A LF, %7F DEL) that browsers
+  // strip from URL schemes; removed during canonicalization so encoded scheme splits are detected.
+  private static final Pattern ENCODED_CONTROL_CHAR =
+      Pattern.compile("%(0[0-9a-f]|1[0-9a-f]|7f)", Pattern.CASE_INSENSITIVE);
+
   public static boolean isSafe(String svgContent) {
     try {
       Document doc = Jsoup.parse(svgContent, "", org.jsoup.parser.Parser.xmlParser());
@@ -42,30 +53,35 @@ public class SVGSecurityScanner implements DocumentDetector {
         return false;
       }
       for (Element el : doc.getAllElements()) {
+        if (SMIL_ANIMATION_ELEMENTS.contains(el.tagName().toLowerCase(Locale.ROOT))) {
+          String animatedAttr = el.attributes().getIgnoreCase("attributeName").toLowerCase(Locale.ROOT).trim();
+          if (isDangerousAttributeName(animatedAttr)) {
+            return false;
+          }
+        }
+
         for (Attribute attr : el.attributes()) {
           String key = attr.getKey().toLowerCase(Locale.ROOT);
           String val = attr.getValue();
-          String valLower = val.toLowerCase(Locale.ROOT).trim();
 
           if (key.startsWith("on")) {
             return false;
           }
 
           if (HREF_ATTRS.contains(key) || key.endsWith(":href")) { // covers namespaced forms
-            if (DANGEROUS_SCHEME.matcher(valLower).find()) {
+            if (hasDangerousScheme(val)) {
               return false;
             }
           }
 
           if ("style".equals(key)) {
+            String valLower = val.toLowerCase(Locale.ROOT).trim();
             if (CSS_EXPRESSION.matcher(valLower).find()) {
               return false;
             }
             Matcher m = CSS_URL.matcher(valLower);
             while (m.find()) {
-              String url = m.group(2).trim();
-              String urlLower = url.toLowerCase(Locale.ROOT);
-              if (DANGEROUS_SCHEME.matcher(urlLower).find()) {
+              if (hasDangerousScheme(m.group(2))) {
                 return false;
               }
             }
@@ -74,16 +90,13 @@ public class SVGSecurityScanner implements DocumentDetector {
       }
 
       for (Element style : doc.select("style")) {
-        String css = style.data();
-        String cssLower = css.toLowerCase(Locale.ROOT);
+        String cssLower = style.data().toLowerCase(Locale.ROOT);
         if (CSS_EXPRESSION.matcher(cssLower).find()) {
           return false;
         }
         Matcher m = CSS_URL.matcher(cssLower);
         while (m.find()) {
-          String url = m.group(2).trim();
-          String urlLower = url.toLowerCase(Locale.ROOT);
-          if (DANGEROUS_SCHEME.matcher(urlLower).find()) {
+          if (hasDangerousScheme(m.group(2))) {
             return false;
           }
         }
@@ -94,6 +107,41 @@ public class SVGSecurityScanner implements DocumentDetector {
       Ivy.log().error("SVG security check failed", e);
       return false;
     }
+  }
+
+  private static boolean isDangerousAttributeName(String attributeName) {
+    return attributeName.startsWith("on") || HREF_ATTRS.contains(attributeName)
+        || attributeName.endsWith(":href");
+  }
+
+  /**
+   * Returns true if the value resolves to a dangerous URL scheme (javascript:, vbscript:, data:).
+   * The value is canonicalized first so that schemes obfuscated with control characters or their
+   * percent-encoded forms - e.g. "java&#9;script:" (TAB), "java&#10;script:" (LF), "java%09script:"
+   * - are detected the same way a browser would after stripping those characters.
+   */
+  private static boolean hasDangerousScheme(String value) {
+    if (value == null) {
+      return false;
+    }
+    return DANGEROUS_SCHEME.matcher(canonicalizeScheme(value)).find();
+  }
+
+  private static String canonicalizeScheme(String value) {
+    String lower = value.toLowerCase(Locale.ROOT);
+    // Drop percent-encoded ASCII control/whitespace bytes (browsers ignore them inside schemes).
+    lower = ENCODED_CONTROL_CHAR.matcher(lower).replaceAll("");
+    // Drop raw ASCII whitespace and control characters - including TAB/LF/CR that jsoup already
+    // decoded from numeric character references such as &#9; / &#10; - so a scheme split across
+    // those characters collapses back to its canonical form before the dangerous-scheme check.
+    StringBuilder canonical = new StringBuilder(lower.length());
+    for (int i = 0; i < lower.length(); i++) {
+      char c = lower.charAt(i);
+      if (c > 0x20 && c != 0x7f) {
+        canonical.append(c);
+      }
+    }
+    return canonical.toString();
   }
 
   @Override

--- a/AxonIvyPortal/portal/cms/cms.yaml
+++ b/AxonIvyPortal/portal/cms/cms.yaml
@@ -194,7 +194,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       enableGroupChat: Set this property to true to enable group chat function
       enablePrivateChat: Set this property to true to enable private chat function
       enableProcessViewer: Set this property to true to enable process viewer option in Task/Case actions
-      enableScriptCheckingForUploadedDocumentNote: Set to true to enable script checking for uploaded document. Currently this function supports checking for PDF, Excel, Word.
+      enableScriptCheckingForUploadedDocumentNote: Set to true to enable script checking for uploaded document. Currently this function supports checking for PDF, Excel, Word, SVG.
       enableVirusScannerForUploadedDocumentNote: Set to true to enable virus scanner for uploaded document. Currently this function is using API VIRUSTOTAL.
       hideCaseDocument: Set to true, the document section in case detail page will be hidden, otherwise it will be shown.
       hideChangePasswordButtonNote: Set this variable to true to hide the "Change Password" option in the top menu and the "Forgotten Password" option on the login page. If set to false, these options will be shown.

--- a/AxonIvyPortal/portal/cms/cms_de.yaml
+++ b/AxonIvyPortal/portal/cms/cms_de.yaml
@@ -273,7 +273,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       enablePinTask: Setzen Sie diese Eigenschaft auf „true“, um das Anheften von Aufgaben zu ermöglichen.
       enablePrivateChat: Setzen Sie diese Einstellung auf "true", um den privaten Chat zu aktivieren
       enableProcessViewer: Setzen Sie diese Einstellung auf true, um die Prozess-Viewer-Option in Aufgaben-/Vorgang-Aktionen zu aktivieren
-      enableScriptCheckingForUploadedDocumentNote: Auf "true" setzen, um die Skriptüberprüfung zu aktivieren. Es werden die Formate PDF, Excel und Word unterstützt.
+      enableScriptCheckingForUploadedDocumentNote: Auf "true" setzen, um die Skriptüberprüfung zu aktivieren. Es werden die Formate PDF, Excel, Word und SVG unterstützt.
       enableTranslationService: Setzen Sie diese Eigenschaft auf true, um den Übersetzungsdienst zu aktivieren
       enableVirusScannerForUploadedDocumentNote: Auf true setzen, um den Virenscanner für das hochgeladene Dokument zu aktivieren. Derzeit verwendet diese Funktion die API VIRUSTOTAL.
       hideCaseCreator: |

--- a/AxonIvyPortal/portal/cms/cms_en.yaml
+++ b/AxonIvyPortal/portal/cms/cms_en.yaml
@@ -272,7 +272,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       enablePinTask: Set this property to true to enable the ability to pin tasks.
       enablePrivateChat: Set this property to true to enable private chat function
       enableProcessViewer: Set this property to true to enable process viewer option in Task/Case actions
-      enableScriptCheckingForUploadedDocumentNote: Set to true to enable script checking for uploaded document. Currently this function supports checking for PDF, Excel, Word.
+      enableScriptCheckingForUploadedDocumentNote: Set to true to enable script checking for uploaded document. Currently this function supports checking for PDF, Excel, Word, SVG.
       enableTranslationService: Set this property to true to enable translation service support
       enableVirusScannerForUploadedDocumentNote: Set to true to enable virus scanner for uploaded document. Currently this function is using API VIRUSTOTAL.
       hideCaseCreator: |-

--- a/AxonIvyPortal/portal/cms/cms_es.yaml
+++ b/AxonIvyPortal/portal/cms/cms_es.yaml
@@ -273,7 +273,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       enablePinTask: Establece esta propiedad en true para habilitar la función de fijar tareas.
       enablePrivateChat: Cambie esta propiedad a "true" para activar el chat privado
       enableProcessViewer: Defina esta propiedad como true para habilitar la opción de visor de procesos en las acciones de Tarea/Caso
-      enableScriptCheckingForUploadedDocumentNote: 'Cambiar a "True" para activar el control de anexos permitidos. De momento se pueden controlar archivos en PDF, word y excel. '
+      enableScriptCheckingForUploadedDocumentNote: 'Cambiar a "True" para activar el control de anexos permitidos. De momento se pueden controlar archivos en PDF, word, excel y SVG.'
       enableTranslationService: Establezca esta propiedad en true para habilitar el servicio de traducción
       enableVirusScannerForUploadedDocumentNote: Cambiar a "true" para habilitar el escáner de virus para el documento cargado. Actualmente esta función utiliza la API VIRUSTOTAL.
       hideCaseCreator: |-

--- a/AxonIvyPortal/portal/cms/cms_fr.yaml
+++ b/AxonIvyPortal/portal/cms/cms_fr.yaml
@@ -273,7 +273,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       enablePinTask: Définissez cette propriété sur true pour activer la possibilité d’épingler des tâches.
       enablePrivateChat: Définissez cette propriété à true pour activer la fonction de chat privé
       enableProcessViewer: Définissez cette propriété à true pour activer l'option de visualisation de processus dans les actions de Task/Case.
-      enableScriptCheckingForUploadedDocumentNote: Défini sur true pour activer la vérification de script pour le document téléchargé. Actuellement, cette fonction prend en charge la vérification de PDF, Excel, Word.
+      enableScriptCheckingForUploadedDocumentNote: Défini sur true pour activer la vérification de script pour le document téléchargé. Actuellement, cette fonction prend en charge la vérification de PDF, Excel, Word, SVG.
       enableTranslationService: Définissez cette propriété sur true pour activer le service de traduction
       enableVirusScannerForUploadedDocumentNote: Définie sur true pour activer le scanner de virus pour le document téléchargé. Actuellement, cette fonction utilise l'API VIRUSTOTAL.
       hideCaseCreator: |-

--- a/AxonIvyPortal/portal/cms/cms_ja.yaml
+++ b/AxonIvyPortal/portal/cms/cms_ja.yaml
@@ -273,7 +273,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       enablePinTask: このプロパティをtrueに設定すると、タスクをピンする機能が有効になります。
       enablePrivateChat: 個人用チャット機能を有効にするには、このプロパティーを true に設定してください。
       enableProcessViewer: タスク／ケースアクションでプロセスビューアーオプションを有効にするには、このプロパティをtrueに設定してください。
-      enableScriptCheckingForUploadedDocumentNote: アップロードされたドキュメントのスクリプトチェックを有効にするには、true に設定してください。現在、この機能は PDF、Excel、Word のチェックをサポートしています。
+      enableScriptCheckingForUploadedDocumentNote: アップロードされたドキュメントのスクリプトチェックを有効にするには、true に設定してください。現在、この機能は PDF、Excel、Word、SVG のチェックをサポートしています。
       enableTranslationService: このプロパティをtrueに設定すると、翻訳サービスのサポートが有効になります。
       enableVirusScannerForUploadedDocumentNote: アップロードされたドキュメントへのウイルススキャナーを有効にするには true に設定してください。現在、この機能は API VIRUSTOTAL を使用しています。
       hideCaseCreator: |-

--- a/Documentation/portal-guide/source/portal-developer-guide/customization/portal-style-customization-logos-colors-date-patterns.rst
+++ b/Documentation/portal-guide/source/portal-developer-guide/customization/portal-style-customization-logos-colors-date-patterns.rst
@@ -32,6 +32,12 @@ render SVG graphics.
 On the other hand, PNG logos may blur when expanded, and they result in large
 file sizes if supplied in high resolution to prevent the blurring.
 
+.. note::
+   SVG is an XML format that can embed scripts. Portal renders logos as static
+   images (HTML ``<img>``), so any script embedded in an uploaded SVG does not
+   execute, and uploaded SVGs are additionally scanned for script-like content.
+   As defense in depth, only use SVG files from trusted sources.
+
 We recommend using images with a transparent background, if your Corporate
 Identity does not define a mandatory background color. 
 

--- a/Documentation/portal-guide/source/portal-developer-guide/customization/process-image.rst
+++ b/Documentation/portal-guide/source/portal-developer-guide/customization/process-image.rst
@@ -25,6 +25,8 @@ Define Your Own Process Image
    .. tip::
       - Prefer SVG for crisp scaling. PNG/JPG are supported; keep file size small.
       - Recommended visual box: square aspect ratio (e.g., 64x64 or 128x128) for consistent card rendering.
+      - SVG can embed scripts; use SVG files from trusted sources only. Portal renders process
+        images as static ``<img>`` elements, so embedded scripts do not execute.
 
 #. Define a custom field ``processImage`` in :guilabel:`Custom Fields` of the process start.
    The value of this custom field is the CMS object which you created above.


### PR DESCRIPTION
Reject SMIL animation elements (set/animate/animateTransform/animateMotion) whose attributeName targets href/xlink:href or an on* event handler, and canonicalize URL values - stripping raw and percent-encoded ASCII control/whitespace characters - before the dangerous-scheme check. This closes scanner bypasses using SMIL attribute assignment and TAB/LF-split javascript: schemes.

Docs: note that uploaded SVGs are rendered as static images and should come from trusted sources (logo and process-image guides), and list SVG in the EnableScriptChecking setting note across locales.