### PR TITLE
IVYPORTAL-20622 Wrong decimal numbers in custom fields

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
@@ -3,11 +3,13 @@ package ch.ivy.addon.portalkit.dto.dashboard;
 import static ch.ivy.addon.portalkit.constant.DashboardConfigurationPrefix.CMS;
 
 import java.io.Serializable;
+import java.text.DecimalFormat;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.validator.ValidatorException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -53,5 +55,37 @@ public class ColumnModel extends AbstractColumn implements Serializable {
       return PortalCustomFieldUtils.getDisplayValueByField(customFields, field);
     }
     return customFields.stringField(field).getOrNull();
+  }
+  
+  /**
+   * This is fix for input Japanese yen throw exception with pattern: \u00A5###,###.###
+   * Reason: The pattern is being stored as the literal 6-character escape sequence \u00A5 (backslash + u + 0 + 0 + A + 5) instead of the actual yen character ¥. 
+   * This happens when someone types \u00A5 in a text input field — the UI form doesn't interpret Unicode escapes, it stores them verbatim.
+   * When new DecimalFormat(pattern) receives this 16-character string, it parses it character by character looking for the start of the number pattern (the first 0 or #)
+   * @param pattern
+   * @return resolved pattern
+   */
+  private String resolveUnicodeEscapes(String pattern) {
+    StringBuffer sb = new StringBuffer();
+    java.util.regex.Matcher m = java.util.regex.Pattern
+        .compile("\\\\u([0-9A-Fa-f]{4})")
+        .matcher(pattern);
+    while (m.find()) {
+        m.appendReplacement(sb, String.valueOf((char) Integer.parseInt(m.group(1), 16)));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+}
+  protected Object displayNumberWithPattern(ICustomFields customFields) {
+    Number value = customFields.numberField(field).getOrNull();
+    if (StringUtils.isNotEmpty(pattern)) {
+      try {
+          String resolvedPattern = resolveUnicodeEscapes(pattern);
+          return new DecimalFormat(resolvedPattern).format(value);
+      } catch (IllegalArgumentException e) {
+          return value; // fall back to raw number
+      }
+    }
+    return value;
   }
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
@@ -4,6 +4,7 @@ import static ch.ivy.addon.portalkit.constant.DashboardConfigurationPrefix.CMS;
 
 import java.io.Serializable;
 import java.text.DecimalFormat;
+import java.util.regex.Pattern;
 
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
@@ -61,8 +62,8 @@ public class ColumnModel extends AbstractColumn implements Serializable {
    * Resolves literal Unicode escape sequences (e.g. "\\u00A5") into their corresponding characters (e.g. "¥").
    * This is needed when a user types the escape sequence into a text input, because the UI stores it verbatim.
    */
-  private static final java.util.regex.Pattern UNICODE_ESCAPE_PATTERN =
-      java.util.regex.Pattern.compile("\\\\u([0-9A-Fa-f]{4})");
+  private static final Pattern UNICODE_ESCAPE_PATTERN =
+      Pattern.compile("\\\\u([0-9A-Fa-f]{4})");
 
   private String resolveUnicodeEscapes(String pattern) {
     StringBuffer sb = new StringBuffer();

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
@@ -58,24 +58,22 @@ public class ColumnModel extends AbstractColumn implements Serializable {
   }
   
   /**
-   * This is fix for input Japanese yen throw exception with pattern: \u00A5###,###.###
-   * Reason: The pattern is being stored as the literal 6-character escape sequence \u00A5 (backslash + u + 0 + 0 + A + 5) instead of the actual yen character ¥. 
-   * This happens when someone types \u00A5 in a text input field — the UI form doesn't interpret Unicode escapes, it stores them verbatim.
-   * When new DecimalFormat(pattern) receives this 16-character string, it parses it character by character looking for the start of the number pattern (the first 0 or #)
-   * @param pattern
-   * @return resolved pattern
+   * Resolves literal Unicode escape sequences (e.g. "\\u00A5") into their corresponding characters (e.g. "¥").
+   * This is needed when a user types the escape sequence into a text input, because the UI stores it verbatim.
    */
+  private static final java.util.regex.Pattern UNICODE_ESCAPE_PATTERN =
+      java.util.regex.Pattern.compile("\\\\u([0-9A-Fa-f]{4})");
+
   private String resolveUnicodeEscapes(String pattern) {
     StringBuffer sb = new StringBuffer();
-    java.util.regex.Matcher m = java.util.regex.Pattern
-        .compile("\\\\u([0-9A-Fa-f]{4})")
-        .matcher(pattern);
+    java.util.regex.Matcher m = UNICODE_ESCAPE_PATTERN.matcher(pattern);
     while (m.find()) {
-        m.appendReplacement(sb, String.valueOf((char) Integer.parseInt(m.group(1), 16)));
+      String replacement = String.valueOf((char) Integer.parseInt(m.group(1), 16));
+      m.appendReplacement(sb, java.util.regex.Matcher.quoteReplacement(replacement));
     }
     m.appendTail(sb);
     return sb.toString();
-}
+  }
   protected Object displayNumberWithPattern(ICustomFields customFields) {
     Number value = customFields.numberField(field).getOrNull();
     if (value == null) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
@@ -78,14 +78,19 @@ public class ColumnModel extends AbstractColumn implements Serializable {
 }
   protected Object displayNumberWithPattern(ICustomFields customFields) {
     Number value = customFields.numberField(field).getOrNull();
-    if (StringUtils.isNotEmpty(pattern)) {
-      try {
-          String resolvedPattern = resolveUnicodeEscapes(pattern);
-          return new DecimalFormat(resolvedPattern).format(value);
-      } catch (IllegalArgumentException e) {
-          return value; // fall back to raw number
-      }
+    if (value == null) {
+      return null;
     }
-    return value;
+
+    java.util.Locale locale = Ivy.session().getFormattingLocale();
+    try {
+      if (StringUtils.isNotBlank(pattern)) {
+        String resolvedPattern = resolveUnicodeEscapes(pattern);
+        return new DecimalFormat(resolvedPattern, new java.text.DecimalFormatSymbols(locale)).format(value);
+      }
+      return java.text.NumberFormat.getNumberInstance(locale).format(value);
+    } catch (IllegalArgumentException e) {
+      return value; // fall back to raw number
+    }
   }
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CaseColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CaseColumnModel.java
@@ -31,8 +31,6 @@ public class CaseColumnModel extends ColumnModel {
     }
   }
 
-  
-  
   public static CaseColumnModel constructColumn(DashboardColumnType fieldType, String field) {
     CaseColumnModel column = new CaseColumnModel();
     if (fieldType == DashboardColumnType.STANDARD) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CaseColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CaseColumnModel.java
@@ -21,7 +21,7 @@ public class CaseColumnModel extends ColumnModel {
   public Object display(ICase caze) {
     ICustomFields customFields = caze.customFields();
     if (isNumber()) {
-      return customFields.numberField(field).getOrNull();
+      return displayNumberWithPattern(customFields);
     } else if (isDate()) {
       return customFields.timestampField(field).getOrNull();
     } else if (isText()) {
@@ -31,6 +31,8 @@ public class CaseColumnModel extends ColumnModel {
     }
   }
 
+  
+  
   public static CaseColumnModel constructColumn(DashboardColumnType fieldType, String field) {
     CaseColumnModel column = new CaseColumnModel();
     if (fieldType == DashboardColumnType.STANDARD) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/TaskColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/TaskColumnModel.java
@@ -29,7 +29,7 @@ public class TaskColumnModel extends ColumnModel {
 
   private Object getCustomFieldValue(ICustomFields customFields) {
     if (isNumber()) {
-      return customFields.numberField(field).getOrNull();
+      return displayNumberWithPattern(customFields);
     } else if (isDate()) {
       return customFields.timestampField(field).getOrNull();
     } else if (isText()) {

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidget/CaseWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidget/CaseWidget.xhtml
@@ -121,9 +121,7 @@
           </h:panelGroup>
 
           <h:panelGroup rendered="#{column.format eq 'NUMBER'}">
-            <h:outputText value="#{column.display(caseItem)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}">
-              <f:convertNumber pattern="#{column.pattern}" />
-            </h:outputText>
+            <h:outputText value="#{column.display(caseItem)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}" />
           </h:panelGroup>
 
           <h:panelGroup rendered="#{column.field eq 'category'}">

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidget/TaskWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidget/TaskWidget.xhtml
@@ -125,9 +125,7 @@
           </h:panelGroup>
           
           <h:panelGroup rendered="#{column.format eq 'NUMBER'}">
-            <h:outputText value="#{column.display(task)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}">
-              <f:convertNumber pattern="#{column.pattern}" />
-            </h:outputText>
+            <h:outputText value="#{column.display(task)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}" />
           </h:panelGroup>
 
           <h:panelGroup rendered="#{column.field eq 'category'}">


### PR DESCRIPTION
- Root cause f:convertNumber is a JSF tag handler, not a regular component. Tag handlers are processed during the view build phase — before p:columns sets up its iteration variable column. At build time, #{column.pattern} evaluates to null because column is not yet in the EL context.