### PR TITLE
Refactor nesting issues

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/AbsenceManagementBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/AbsenceManagementBean.java
@@ -485,16 +485,19 @@ public class AbsenceManagementBean implements Serializable {
   }
 
   public void saveSubstitutes() {
-    if (selectedDeputyRole != null) {
-      if (createDeputyMode) {
-        for (ISecurityMember member : selectedDeputies) {
-          if (!selectedDeputyRole.getDeputies().contains(member)) {
-            selectedDeputyRole.getDeputies().add(member);
-          }
+    if (selectedDeputyRole == null) {
+      persistAllSubstitutes();
+      return;
+    }
+    if (createDeputyMode) {
+      var existing = selectedDeputyRole.getDeputies();
+      for (ISecurityMember member : selectedDeputies) {
+        if (!existing.contains(member)) {
+          existing.add(member);
         }
-      } else {
-        selectedDeputyRole.setDeputies(selectedDeputies);
       }
+    } else {
+      selectedDeputyRole.setDeputies(selectedDeputies);
     }
     persistAllSubstitutes();
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/TaskBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/TaskBean.java
@@ -115,35 +115,51 @@ public class TaskBean implements Serializable {
   public String getAriaLabel(ITask task, List<TaskColumnModel> columns) {
     List<String> displayTexts = new ArrayList<>();
     for (TaskColumnModel col : columns) {
-      if (col.getVisible()) {
-        if (DashboardStandardTaskColumn.START.getField().equalsIgnoreCase(col.getField())) {
-          displayTexts.add(cms("/ch.ivy.addon.portalkit.ui.jsf/dashboard/taskStart"));
-        } else if (DashboardStandardTaskColumn.PRIORITY.getField().equalsIgnoreCase(col.getField())) {
-          displayTexts.add(col.getHeaderText() + ": " + getPriority(task.getPriority()));
-        } else if (DashboardStandardTaskColumn.STATE.getField().equalsIgnoreCase(col.getField())) {
-          displayTexts.add(col.getHeaderText() + ": " + getTaskBusinessState(task.getBusinessState()));
-        } else if (DashboardStandardTaskColumn.CREATED.getField().equalsIgnoreCase(col.getField())) {
-          String createdDateString = new SimpleDateFormat(DateTimeGlobalSettingService.getInstance().getGlobalDateTimePattern()).format(task.getStartTimestamp());
-          displayTexts.add(col.getHeaderText() + ": " + createdDateString);
-        } else if (DashboardStandardTaskColumn.COMPLETED.getField().equalsIgnoreCase(col.getField())) {
-          if (task.getEndTimestamp() != null) {
-            String completedDateString = new SimpleDateFormat(DateTimeGlobalSettingService.getInstance().getGlobalDateTimePattern()).format(task.getEndTimestamp());
-            displayTexts.add(col.getHeaderText() + ": " + completedDateString);
-          }
-        } else if (DashboardStandardTaskColumn.EXPIRY.getField().equalsIgnoreCase(col.getField())) {
-          if (task.getExpiryTimestamp() != null) {
-            String expiryDateString = new SimpleDateFormat(DateTimeGlobalSettingService.getInstance().getGlobalDateTimePattern()).format(task.getExpiryTimestamp());
-            displayTexts.add(col.getHeaderText() + ": " + expiryDateString);
-          }
-        } else {
-          Object displayObject = col.display(task);
-          if (displayObject != null && StringUtils.isNotEmpty(displayObject.toString())) {
-            displayTexts.add(col.getHeaderText() + ": " + displayObject.toString());
-          }
-        }
+      if (!col.getVisible()) {
+        continue;
+      }
+      String text = ariaLabelFor(task, col);
+      if (text != null) {
+        displayTexts.add(text);
       }
     }
     return String.join(" - ", displayTexts);
+  }
+
+  private String ariaLabelFor(ITask task, TaskColumnModel col) {
+    String field = col.getField();
+    if (DashboardStandardTaskColumn.START.getField().equalsIgnoreCase(field)) {
+      return cms("/ch.ivy.addon.portalkit.ui.jsf/dashboard/taskStart");
+    }
+    if (DashboardStandardTaskColumn.PRIORITY.getField().equalsIgnoreCase(field)) {
+      return col.getHeaderText() + ": " + getPriority(task.getPriority());
+    }
+    if (DashboardStandardTaskColumn.STATE.getField().equalsIgnoreCase(field)) {
+      return col.getHeaderText() + ": " + getTaskBusinessState(task.getBusinessState());
+    }
+    if (DashboardStandardTaskColumn.CREATED.getField().equalsIgnoreCase(field)) {
+      return col.getHeaderText() + ": " + formatDateTime(task.getStartTimestamp());
+    }
+    if (DashboardStandardTaskColumn.COMPLETED.getField().equalsIgnoreCase(field)) {
+      return task.getEndTimestamp() == null ? null
+          : col.getHeaderText() + ": " + formatDateTime(task.getEndTimestamp());
+    }
+    if (DashboardStandardTaskColumn.EXPIRY.getField().equalsIgnoreCase(field)) {
+      return task.getExpiryTimestamp() == null ? null
+          : col.getHeaderText() + ": " + formatDateTime(task.getExpiryTimestamp());
+    }
+    Object displayObject = col.display(task);
+    if (displayObject == null) {
+      return null;
+    }
+    String displayText = displayObject.toString();
+    return StringUtils.isEmpty(displayText) ? null
+        : col.getHeaderText() + ": " + displayText;
+  }
+
+  private static String formatDateTime(java.util.Date timestamp) {
+    return new SimpleDateFormat(
+        DateTimeGlobalSettingService.getInstance().getGlobalDateTimePattern()).format(timestamp);
   }
 
   public boolean isPinnedTask(ITask task) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
@@ -241,21 +241,20 @@ public class TaskSearchCriteria {
     }
 
     private void appendSortByExpiryDateIfSet(TaskSearchCriteria criteria) {
-      if (TaskSortField.EXPIRY_TIME.toString().equalsIgnoreCase(criteria.getSortField())) {
-        if (criteria.isQuickGlobalSearch()) {
-          if (criteria.isSortDescending()) {
-            query.orderBy().expiryTimestamp().descendingNullLast();
-          } else {
-            query.orderBy().expiryTimestamp().ascendingNullFirst();
-          }
-        } else {
-          if (criteria.isSortDescending()) {
-            query.orderBy().expiryTimestamp().descendingNullFirst();
-          } else {
-            query.orderBy().expiryTimestamp().ascendingNullLast();
-          }
-        }
-
+      if (!TaskSortField.EXPIRY_TIME.toString().equalsIgnoreCase(criteria.getSortField())) {
+        return;
+      }
+      var order = query.orderBy().expiryTimestamp();
+      boolean descending = criteria.isSortDescending();
+      boolean quick = criteria.isQuickGlobalSearch();
+      if (descending && quick) {
+        order.descendingNullLast();
+      } else if (descending) {
+        order.descendingNullFirst();
+      } else if (quick) {
+        order.ascendingNullFirst();
+      } else {
+        order.ascendingNullLast();
       }
     }
     

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/AbsenceService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/AbsenceService.java
@@ -35,7 +35,9 @@ public class AbsenceService{
             ivyAbsencesByUser.put(user.getName(), getAbsences(user)));
       } else {
         IUser user = UserUtils.findUserByUsername(username);
-        ivyAbsencesByUser.put(username, getAbsences(user));
+        if (user != null) {
+          ivyAbsencesByUser.put(username, getAbsences(user));
+        }
       }
       return ivyAbsencesByUser;
     });

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/AbsenceService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/service/impl/AbsenceService.java
@@ -28,23 +28,14 @@ public class AbsenceService{
   }
   
   public Map<String, Set<IvyAbsence>> findAbsences(String username) {
-    return Sudo.get(() -> { 
+    return Sudo.get(() -> {
       Map<String, Set<IvyAbsence>> ivyAbsencesByUser = new HashMap<>();
       if (StringUtils.isBlank(username)) {
-          ServiceUtilities.findAllUsers().forEach(user -> {
-          if (ivyAbsencesByUser.containsKey(user.getName())) {
-            ivyAbsencesByUser.get(user.getName()).addAll(getAbsences(user));
-          } else {
-            ivyAbsencesByUser.put(user.getName(), getAbsences(user));
-          }
-        });
+        ServiceUtilities.findAllUsers().forEach(user ->
+            ivyAbsencesByUser.put(user.getName(), getAbsences(user)));
       } else {
         IUser user = UserUtils.findUserByUsername(username);
-        if (ivyAbsencesByUser.containsKey(user.getName())) {
-          ivyAbsencesByUser.get(username).addAll(getAbsences(user));
-        } else {
-          ivyAbsencesByUser.put(username, getAbsences(user));
-        }
+        ivyAbsencesByUser.put(username, getAbsences(user));
       }
       return ivyAbsencesByUser;
     });

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/DashboardImportBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/DashboardImportBean.java
@@ -145,31 +145,33 @@ public class DashboardImportBean extends DashboardModificationBean {
 
   @Override
   public void createDashboard() {
-    if (CollectionUtils.isNotEmpty(importedDashboards)) {
-      for (Dashboard dashboard : importedDashboards) {
-        selectedDashboard = dashboard;
-        if (CollectionUtils.isNotEmpty(this.selectedDashboard.getWidgets())) {
-          for (DashboardWidget widget : this.selectedDashboard.getWidgets()) {
-            if (widget instanceof WelcomeDashboardWidget) {
-              WelcomeDashboardWidget welcomeWidget = (WelcomeDashboardWidget) widget;
-              WelcomeWidgetUtils.writeWelcomeWidgetImage(welcomeWidget);
-            } else if (widget instanceof NavigationDashboardWidget) {
-              NavigationDashboardWidget navWid = (NavigationDashboardWidget) widget;
-              NavigationWidgetUtils.writeNavigateWidgetImage(navWid);
-            }
-          }
-        }
-        createDashboards();
-      }
-      fixExistingNavigationWidgetReferences();
-      if (importedDashboards.size() > 1) {
-        if (this.isPublicDashboard) {
-          navigateToPublicDashBoardListPage();
-        } else {
-          navigateToPrivateDashboardPage();
-        }
-      } else {
-        navigateToDashboardDetailsPage(importedDashboards.get(0).getId());
+    if (CollectionUtils.isEmpty(importedDashboards)) {
+      return;
+    }
+    for (Dashboard dashboard : importedDashboards) {
+      selectedDashboard = dashboard;
+      writeWidgetImagesFor(selectedDashboard);
+      createDashboards();
+    }
+    fixExistingNavigationWidgetReferences();
+    if (importedDashboards.size() == 1) {
+      navigateToDashboardDetailsPage(importedDashboards.get(0).getId());
+    } else if (this.isPublicDashboard) {
+      navigateToPublicDashBoardListPage();
+    } else {
+      navigateToPrivateDashboardPage();
+    }
+  }
+
+  private void writeWidgetImagesFor(Dashboard dashboard) {
+    if (CollectionUtils.isEmpty(dashboard.getWidgets())) {
+      return;
+    }
+    for (DashboardWidget widget : dashboard.getWidgets()) {
+      if (widget instanceof WelcomeDashboardWidget) {
+        WelcomeWidgetUtils.writeWelcomeWidgetImage((WelcomeDashboardWidget) widget);
+      } else if (widget instanceof NavigationDashboardWidget) {
+        NavigationWidgetUtils.writeNavigateWidgetImage((NavigationDashboardWidget) widget);
       }
     }
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/validator/NewsEditorValidator.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/validator/NewsEditorValidator.java
@@ -26,14 +26,12 @@ public class NewsEditorValidator implements Validator {
     }
     String content = (String) value;
     content = HtmlParser.extractTextFromHtml(content);
-    if (StringUtils.isNoneBlank(content)) {
-      if (content.length() > MAX_NEWS_CONTENT_LENGTH) {
-        var message = FacesMessageUtils.sanitizedMessage(FacesMessage.SEVERITY_ERROR,
-            Ivy.cms().co("/Dialogs/com/axonivy/portal/dashboard/component/NewsWidgetConfiguration/NewsContentMaxLengthMessage"),
-            "");
-        FacesContext.getCurrentInstance().addMessage(null, message);
-        FacesContext.getCurrentInstance().validationFailed();
-      }
+    if (StringUtils.isNoneBlank(content) && content.length() > MAX_NEWS_CONTENT_LENGTH) {
+      var message = FacesMessageUtils.sanitizedMessage(FacesMessage.SEVERITY_ERROR,
+          Ivy.cms().co("/Dialogs/com/axonivy/portal/dashboard/component/NewsWidgetConfiguration/NewsContentMaxLengthMessage"),
+          "");
+      FacesContext.getCurrentInstance().addMessage(null, message);
+      FacesContext.getCurrentInstance().validationFailed();
     }
   }
 }


### PR DESCRIPTION
Flattens unnecessarily nested code in the Portal codebase. Each commit is one focused, semantically-equivalent refactor:

1. NewsEditorValidator — collapsed two nested ifs into a single &&
2. DashboardImportBean.createDashboard — wrapping if(isNotEmpty) → early return; extracted widget-image helper
3. AbsenceManagementBean.saveSubstitutes — wrapping null-check → early return; hoisted repeated getter call
4. AbsenceService.findAbsences — removed unreachable containsKey branches (map was freshly empty)
5. TaskSearchCriteria.appendSortByExpiryDateIfSet — 3-level nest of a 2×2 truth table → flat else-if chain
6. TaskBean.getAriaLabel — 4-level nest with 7-branch cascade → continue guard + extracted ariaLabelFor helper

Scope: Structural cleanup only. No logic changes, no API changes, no new dependencies.