### PR TITLE
IVYPORTAL-20659 Fix task state management for notification handlers

### DIFF
--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/NotificationBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/NotificationBean.java
@@ -10,6 +10,7 @@ import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.FacesContext;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.primefaces.PrimeFaces;
 
 import com.axonivy.portal.components.service.IvyAdapterService;
@@ -191,10 +192,14 @@ public class NotificationBean implements Serializable {
     FacesContext context = FacesContext.getCurrentInstance();
     String redirectType = context.getExternalContext().getRequestParameterMap().get("redirectType");
     String taskId = context.getExternalContext().getRequestParameterMap().get("taskId");
-    // Resolve the task with an involvement-scoped lookup so a user can only leave/reserve
-    // a task they are actually involved in. Returns null when the caller has no involvement
-    // (or the id does not exist), which we reject below instead of acting under Sudo.
-    ITask task = TaskUtils.findTaskUserHasPermissionToSee(Long.valueOf(taskId));
+    // taskId is request-supplied: reject a missing/non-numeric value before parsing so it
+    // cannot trigger a parse error. Then resolve with an involvement-scoped lookup so a user
+    // can only leave/reserve a task they are actually involved in; it returns null when the
+    // caller has no involvement (or the id does not exist), which we reject below.
+    if (!NumberUtils.isDigits(taskId)) {
+      return;
+    }
+    ITask task = TaskUtils.findTaskUserHasPermissionToSee(NumberUtils.toLong(taskId));
     if (task == null) {
       return;
     }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/NotificationBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/NotificationBean.java
@@ -191,8 +191,14 @@ public class NotificationBean implements Serializable {
     FacesContext context = FacesContext.getCurrentInstance();
     String redirectType = context.getExternalContext().getRequestParameterMap().get("redirectType");
     String taskId = context.getExternalContext().getRequestParameterMap().get("taskId");
-    ITask task = TaskUtils.findTaskById(Long.valueOf(taskId));
-    
+    // Resolve the task with an involvement-scoped lookup so a user can only leave/reserve
+    // a task they are actually involved in. Returns null when the caller has no involvement
+    // (or the id does not exist), which we reject below instead of acting under Sudo.
+    ITask task = TaskUtils.findTaskUserHasPermissionToSee(Long.valueOf(taskId));
+    if (task == null) {
+      return;
+    }
+
     executeCustomizedLogicIfExists(task, portalCustomSignature);
     taskHandler.accept(task);
 


### PR DESCRIPTION
The notification panel's leave/reserve remote commands read a client-supplied taskId and resolved it via the involvement-unscoped TaskUtils.findTaskById (Sudo -> Ivy.wf().findTask), then called reset()/parkTask() under Sudo with no ownership check. Any authenticated user could reset or park any other user's in-progress task by supplying an arbitrary task id (workflow DoS).

Resolve the task with the involvement-scoped findTaskUserHasPermissionToSee instead and return early when it is null, so the action only runs on a task the caller is actually involved in.