### PR TITLE
New widget title just entered is cleared after applying predefined filters

### DIFF
--- a/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/SidebarWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/SidebarWidgetConfiguration.xhtml
@@ -194,7 +194,7 @@
             ariaLabel="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/apply')}"
             actionListener="#{taskWidgetConfigurationFilterBean.updateWidgetFilterBeforeApply(widget)}"
             styleClass="Fright preview-button u-hidden-sm-down" icon="ti ti-check"
-            process="predefined-filter"
+            process="predefined-filter widget-title"
             update="predefined-filter configuration-filter-messages-panel"
             oncomplete="closeFilterPanelWithValidation(); if (args &amp;&amp; !args.validationFailed) { updateComponentOnPreviewCmd(); }" />
           <p:commandButton id="reset-filter" icon="ti ti-refresh"


### PR DESCRIPTION
Fix due to failed test: `testEditFilterCaseList` and `testEditFilterTaskList` in https://github.com/axonivy-market/portal/actions/runs/27233174665

I dont totally undertstand but as the change on line 197 in PR #3375 , we change to only process `predefined-filter`. Therefore, when user enter a new title -> then open the manage filters and click save -> but it go to re-render the table so the new title is lost.

With patch in this PR, these 2 tests are again passed. See: https://github.com/axonivy-market/portal/actions/runs/27251707531