### PR TITLE
IVYPORTAL-20666 Case name exposed via iframe

### DIFF
--- a/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
@@ -45,6 +45,7 @@
       
         <c:set var="case" value="#{caseId ne null ? caseWidgetBean.findCase(caseId) : currentTask.getCase().getBusinessCase()}" />
         <c:set var="isSideStepDisabled" value="#{!abstractTaskTemplateBean.checkSideStepsEnabled(case)}" scope="request" />
+        <c:set var="isCaseViewable" value="#{!caseWidgetBean.isHiddenCase(case) and caseWidgetBean.isCaseFound(case)}" scope="request" />
         <ui:insert name="breadCrumb" />
         <p:inputText id="application-name-for-title" value="#{masterDataBean.applicationName}" type="hidden"/>
         <h:panelGroup id="header-container" layout="block" styleClass="task-header-container js-task-header-container #{processChainDirection eq 'VERTICAL' ? '' : 'task-template-title-horizontal-container'}">
@@ -161,13 +162,13 @@
           onShow="PF('caseInfoPoll').start();">
           <f:facet name="header">
             <h:panelGroup styleClass="case-infor-title u-truncate-text">
-              <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/searchResult/case')}#{(!caseWidgetBean.isHiddenCase(case) and caseWidgetBean.isCaseFound(case)) ? ': '.concat(case.names().current()) : ''}" />
+              <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/searchResult/case')}#{isCaseViewable ? ': '.concat(case.names().current()) : ''}" />
             </h:panelGroup>
           </f:facet>
           <ui:insert name="caseDetails">
             <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portal.generic/CaseDetailsTemplate/noCaseFound')}"
-              rendered="#{caseWidgetBean.isHiddenCase(case) or !caseWidgetBean.isCaseFound(case)}" styleClass="no-case-found" />
-            <h:panelGroup id="case-details-panel" layout="block" rendered="#{!caseWidgetBean.isHiddenCase(case) and caseWidgetBean.isCaseFound(case)}"
+              rendered="#{!isCaseViewable}" styleClass="no-case-found" />
+            <h:panelGroup id="case-details-panel" layout="block" rendered="#{isCaseViewable}"
               styleClass="case-default-widget-container case-details case-details-panel">
               <div class="ui-g js-iframe-container">
                 <div class="ui-g-12 u-padding-0">

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
@@ -161,7 +161,7 @@
           onShow="PF('caseInfoPoll').start();">
           <f:facet name="header">
             <h:panelGroup styleClass="case-infor-title u-truncate-text">
-              <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/searchResult/case')}: #{case.names().current()}" />
+              <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/searchResult/case')}#{(!caseWidgetBean.isHiddenCase(case) and caseWidgetBean.isCaseFound(case)) ? ': '.concat(case.names().current()) : ''}" />
             </h:panelGroup>
           </f:facet>
           <ui:insert name="caseDetails">


### PR DESCRIPTION
- The case-info dialog in the task template resolves the request parameter "caseId" through the involvement-unscoped CaseUtils.findCase (Sudo) and renders the case name in the dialog header without any access check, while only the dialog body is gated by isCaseFound. 
- An authenticated user could therefore read the title of any case (enumerable, sequential ids) they have no permission to see.

- Gate the header name with the same condition the body uses (!isHiddenCase and isCaseFound); the static "Case" label still renders for everyone, but the case name is appended only for users who can access it.