### PR TITLE
IVYPORTAL-20666 Avoid NPE when concatenating case name in case info dialog header

### DIFF
--- a/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
@@ -162,7 +162,8 @@
           onShow="PF('caseInfoPoll').start();">
           <f:facet name="header">
             <h:panelGroup styleClass="case-infor-title u-truncate-text">
-              <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/searchResult/case')}#{isCaseViewable ? ': '.concat(case.names().current()) : ''}" />
+              <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/searchResult/case')}" />
+              <h:outputText rendered="#{isCaseViewable and not empty case.names().current()}" value=": #{case.names().current()}" />
             </h:panelGroup>
           </f:facet>
           <ui:insert name="caseDetails">


### PR DESCRIPTION
Splitting the dialog header into two outputText components so a null case name no longer triggers String.concat NPE at render time, matching the null-safe handling used elsewhere in the codebase (CaseExporter, CaseName.xhtml, ProcessHistory.xhtml).

Related to : IVYPORTAL-20666 Case name exposed via iframe