### PR TITLE
IVYPORTAL-20622-Decimal-numbers-in-custom-fields

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/ColumnModel.java
@@ -2,10 +2,14 @@ package ch.ivy.addon.portalkit.dto.dashboard;
 
 import static ch.ivy.addon.portalkit.constant.DashboardConfigurationPrefix.CMS;
 
+import java.text.DecimalFormat;
+import java.util.regex.Pattern;
+
 import javax.faces.component.UIComponent;
 import javax.faces.context.FacesContext;
 import javax.faces.validator.ValidatorException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -50,5 +54,40 @@ public class ColumnModel extends AbstractColumn {
       return PortalCustomFieldUtils.getDisplayValueByField(customFields, field);
     }
     return customFields.stringField(field).getOrNull();
+  }
+
+  /**
+   * Resolves literal Unicode escape sequences (e.g. "\\u00A5") into their corresponding characters (e.g. "¥").
+   * This is needed when a user types the escape sequence into a text input, because the UI stores it verbatim.
+   */
+  private static final Pattern UNICODE_ESCAPE_PATTERN =
+      Pattern.compile("\\\\u([0-9A-Fa-f]{4})");
+
+  private String resolveUnicodeEscapes(String pattern) {
+    StringBuffer sb = new StringBuffer();
+    java.util.regex.Matcher m = UNICODE_ESCAPE_PATTERN.matcher(pattern);
+    while (m.find()) {
+      String replacement = String.valueOf((char) Integer.parseInt(m.group(1), 16));
+      m.appendReplacement(sb, java.util.regex.Matcher.quoteReplacement(replacement));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+  protected Object displayNumberWithPattern(ICustomFields customFields) {
+    Number value = customFields.numberField(field).getOrNull();
+    if (value == null) {
+      return null;
+    }
+
+    java.util.Locale locale = Ivy.session().getFormattingLocale();
+    try {
+      if (StringUtils.isNotBlank(pattern)) {
+        String resolvedPattern = resolveUnicodeEscapes(pattern);
+        return new DecimalFormat(resolvedPattern, new java.text.DecimalFormatSymbols(locale)).format(value);
+      }
+      return java.text.NumberFormat.getNumberInstance(locale).format(value);
+    } catch (IllegalArgumentException e) {
+      return value; // fall back to raw number
+    }
   }
 }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CaseColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/casecolumn/CaseColumnModel.java
@@ -22,7 +22,7 @@ public class CaseColumnModel extends ColumnModel {
   public Object display(ICase caze) {
     ICustomFields customFields = caze.customFields();
     if (isNumber()) {
-      return customFields.numberField(field).getOrNull();
+      return displayNumberWithPattern(customFields);
     } else if (isDate()) {
       return customFields.timestampField(field).getOrNull();
     } else if (isText()) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/TaskColumnModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/taskcolumn/TaskColumnModel.java
@@ -29,7 +29,7 @@ public class TaskColumnModel extends ColumnModel {
 
   private Object getCustomFieldValue(ICustomFields customFields) {
     if (isNumber()) {
-      return customFields.numberField(field).getOrNull();
+      return displayNumberWithPattern(customFields);
     } else if (isDate()) {
       return customFields.timestampField(field).getOrNull();
     } else if (isText()) {

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidget/CaseWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidget/CaseWidget.xhtml
@@ -121,9 +121,7 @@
           </h:panelGroup>
 
           <h:panelGroup rendered="#{column.format eq 'NUMBER'}">
-            <h:outputText value="#{column.display(caseItem)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}">
-              <f:convertNumber pattern="#{column.pattern}" />
-            </h:outputText>
+            <h:outputText value="#{column.display(caseItem)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}" />
           </h:panelGroup>
 
           <h:panelGroup rendered="#{column.field eq 'category'}">

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidget/TaskWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidget/TaskWidget.xhtml
@@ -134,9 +134,7 @@
           </h:panelGroup>
           
           <h:panelGroup rendered="#{column.format eq 'NUMBER'}">
-            <h:outputText value="#{column.display(task)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}">
-              <f:convertNumber pattern="#{column.pattern}" />
-            </h:outputText>
+            <h:outputText value="#{column.display(task)}" styleClass="#{column.fieldStyleClass}" style="#{column.fieldStyle}" />
           </h:panelGroup>
 
           <h:panelGroup rendered="#{column.field eq 'category'}">


### PR DESCRIPTION
- Root cause f:convertNumber is a JSF tag handler, not a regular component. Tag handlers are processed during the view build phase — before p:columns sets up its iteration variable column. At build time, #{column.pattern} evaluates to null because column is not yet in the EL context.

---
_Generated by [Claude Code](https://claude.ai/code/session_019hcu9GWuXh4fu7F4J7xmRc)_