### PR TITLE
 IVYPORTAL-20522 Configure filter operators

### DIFF
--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/Variable.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/common/Variable.java
@@ -40,6 +40,7 @@ public enum Variable {
   DASHBOARD_MAIN_MENU_ENTRY("Portal.Dashboard.MainMenuEntry"), 
   APPLICATION_NAME("Portal.ApplicationName"),
   ENABLE_DOCUMENT_PREVIEW("Portal.Document.EnablePreview"),
+  FILTER_OPERATOR_POLICY("Portal.ComplexFilter.Operators"),
   ENABLE_PINNED_TASK("Portal.Tasks.EnablePinnedTask"), ENABLE_PINNED_CASE("Portal.Cases.EnablePinnedCase"),
   CHECK_SYSTEM_NOTES_BY_DEFAULT("Portal.Histories.CheckSystemNotesByDefault"),
   CHECK_SYSTEM_TASKS_BY_DEFAULT("Portal.Histories.CheckSystemTasksByDefault"),

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/AdminSettingsPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/AdminSettingsPage.java
@@ -36,6 +36,19 @@ public class AdminSettingsPage extends TemplatePage {
   }
 
   private void editGlobalVariable(String variableName, String variableValue, boolean isBooleanType) {
+    openGlobalVariableEditDialog(variableName);
+    waitForElementDisplayed(By.cssSelector("[id$=':settingDialogForm']"), true);
+    saveGlobalVariable(variableValue, isBooleanType);
+  }
+
+  public void updateGlobalMultiSelectionItem(String variableName, String itemValue, boolean shouldBeSelected) {
+    openSettingTab();
+    openGlobalVariableEditDialog(variableName);
+    waitForElementDisplayed(By.cssSelector("[id$=':settingDialogForm']"), true);
+    setMultiSelectionItemStateAndSave(itemValue, shouldBeSelected);
+  }
+
+  private void openGlobalVariableEditDialog(String variableName) {
     $("button[id$='admin-setting-component:adminTabView:restore-all-to-default-button']")
         .shouldBe(Condition.appear, DEFAULT_TIMEOUT).shouldBe(getClickableCondition());
     waitForElementDisplayed(By.id("admin-setting-component:adminTabView:settingTable"), true);
@@ -50,8 +63,42 @@ public class AdminSettingsPage extends TemplatePage {
       String editButtonId = currentElementId.replace("settings-action-button", "edit-application");
       $("a[id='" + editButtonId + "']").shouldBe(getClickableCondition(), DEFAULT_TIMEOUT).click();
     }
-    waitForElementDisplayed(By.cssSelector("[id$=':settingDialogForm']"), true);
-    saveGlobalVariable(variableValue, isBooleanType);
+  }
+
+  private void setMultiSelectionItemStateAndSave(String itemValue, boolean shouldBeSelected) {
+    waitForElementClickableThenClick("[id='admin-setting-component:valueSetting_label']");
+    SelenideElement valueSettingPanel = $(By.id("admin-setting-component:valueSetting_panel"))
+        .shouldBe(Condition.appear, DEFAULT_TIMEOUT);
+
+    SelenideElement valueCheckbox = findMultiSelectionValueCheckbox(valueSettingPanel, itemValue);
+    boolean isSelected = valueCheckbox.getAttribute("class").contains("ui-state-active");
+    if (shouldBeSelected != isSelected) {
+      valueCheckbox.shouldBe(getClickableCondition(), DEFAULT_TIMEOUT).click();
+    }
+
+    closeMultiSelectionPanel(valueSettingPanel);
+    waitForElementClickableThenClick("[id='admin-setting-component:save-setting']");
+  }
+
+  private void closeMultiSelectionPanel(SelenideElement valueSettingPanel) {
+    valueSettingPanel.$("a.ui-selectcheckboxmenu-close").shouldBe(getClickableCondition(), DEFAULT_TIMEOUT).click();
+    valueSettingPanel.shouldBe(Condition.disappear, DEFAULT_TIMEOUT);
+  }
+
+  private SelenideElement findMultiSelectionValueCheckbox(SelenideElement valueSettingPanel, String optionKey) {
+    String normalizedOptionKey = normalizeForLabelComparison(optionKey);
+    for (SelenideElement option : valueSettingPanel.$$("li.ui-selectcheckboxmenu-item")) {
+      String optionLabel = option.$("label").shouldBe(Condition.appear, DEFAULT_TIMEOUT).getText();
+      if (normalizeForLabelComparison(optionLabel).equals(normalizedOptionKey)) {
+        return option.$("div.ui-chkbox-box").shouldBe(Condition.appear, DEFAULT_TIMEOUT);
+      }
+    }
+
+    throw new IllegalArgumentException("Cannot find multi-selection option: " + optionKey);
+  }
+
+  private String normalizeForLabelComparison(String value) {
+    return value.replaceAll("[^A-Za-z0-9]", "").toUpperCase();
   }
 
   public void resetAllSettings() {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TaskWidgetNewDashBoardPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/TaskWidgetNewDashBoardPage.java
@@ -285,6 +285,17 @@ public class TaskWidgetNewDashBoardPage extends TemplatePage {
     getStateFilterCheckBox(state).shouldBe(getClickableCondition(), DEFAULT_TIMEOUT).click();
     getCloseStateFilter().shouldBe(getClickableCondition(), DEFAULT_TIMEOUT).click();
   }
+
+  public void selectPriorityFilterValue(String priorityValue) {
+    $(".dashboard-widget-filter__main-panel")
+        .$$(".dashboard-widget-filter__filter-wrapper").last()
+        .$("div[id$=':priorities']").shouldBe(appear, DEFAULT_TIMEOUT).click();
+    $("div.ui-selectcheckboxmenu-panel[style*='display: block']").shouldBe(appear, DEFAULT_TIMEOUT)
+        .$$("li.ui-selectcheckboxmenu-item").filter(text(priorityValue)).first()
+        .$("div.ui-chkbox-box").click();
+    $("div.ui-selectcheckboxmenu-panel[style*='display: block']")
+        .$("a.ui-selectcheckboxmenu-close").shouldBe(appear, DEFAULT_TIMEOUT).click();
+  }
   
   public void filterTaskState(Object... states) {
     addFilter("State", null);
@@ -548,6 +559,18 @@ public class TaskWidgetNewDashBoardPage extends TemplatePage {
 
   public void addFilter(String columnName, com.axonivy.portal.selenium.common.FilterOperator operator) {
     ComplexFilterHelper.addFilter(columnName, operator);
+  }
+
+  public boolean isOperatorOptionAvailableForFilterField(String fieldName, String operatorLabel) {
+    var filterRow = $("div[class*='dashboard-widget-filter__main-panel']")
+      .$$("div[class*='dashboard-widget-filter__filter-wrapper']").findBy(text(fieldName))
+      .shouldBe(appear, DEFAULT_TIMEOUT);
+
+    var operatorOptions = filterRow.$$("select[id$=':operator-selection_input'] option");
+    operatorOptions.shouldHave(CollectionCondition.sizeGreaterThan(0), DEFAULT_TIMEOUT);
+    return operatorOptions.texts().stream()
+      .map(String::trim)
+      .anyMatch(option -> option.equalsIgnoreCase(operatorLabel.trim()));
   }
   
   public void inputValueOnLatestFilter(FilterValueType type, Object... values) {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/dashboard/DashboardFilterOperatorPolicyTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/dashboard/DashboardFilterOperatorPolicyTest.java
@@ -3,6 +3,9 @@ package com.axonivy.portal.selenium.test.dashboard;
 import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +43,10 @@ public class DashboardFilterOperatorPolicyTest extends BaseTest {
 
   @AfterEach
   public void resetGlobalOperatorPolicy() {
-    updateGlobalVariable(FILTER_OPERATOR_POLICY_KEY, "TODAY,YESTERDAY,IS,IS_NOT,BEFORE,AFTER,BETWEEN,NOT_BETWEEN,CURRENT,LAST,NEXT,EMPTY,NOT_EMPTY,CONTAINS,NOT_CONTAINS,IN,NOT_IN,START_WITH,NOT_START_WITH,END_WITH,NOT_END_WITH,CURRENT_USER_CAN_WORK_ON,CURRENT_USER,NO_CATEGORY,EQUAL,NOT_EQUAL,LESS,LESS_OR_EQUAL,GREATER,GREATER_OR_EQUAL");
+    String allOperators = Arrays.stream(FilterOperator.values())
+      .map(FilterOperator::name)
+      .collect(Collectors.joining(","));
+    updateGlobalVariable(FILTER_OPERATOR_POLICY_KEY, allOperators); 
   }
 
   @Test

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/dashboard/DashboardFilterOperatorPolicyTest.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/test/dashboard/DashboardFilterOperatorPolicyTest.java
@@ -1,0 +1,134 @@
+package com.axonivy.portal.selenium.test.dashboard;
+
+import static com.codeborne.selenide.CollectionCondition.sizeGreaterThanOrEqual;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.axonivy.ivy.webtest.IvyWebTest;
+import com.axonivy.portal.selenium.common.BaseTest;
+import com.axonivy.portal.selenium.common.FilterOperator;
+import com.axonivy.portal.selenium.common.TestAccount;
+import com.axonivy.portal.selenium.common.Variable;
+import com.axonivy.portal.selenium.page.AdminSettingsPage;
+import com.axonivy.portal.selenium.page.NewDashboardPage;
+import com.axonivy.portal.selenium.page.TaskWidgetNewDashBoardPage;
+
+@IvyWebTest
+public class DashboardFilterOperatorPolicyTest extends BaseTest {
+
+  private static final String YOUR_TASKS_WIDGET = "Your Tasks";
+  private static final String CONTAINS_KEY = "CONTAINS";
+  private static final String IN_KEY = "IN";
+  private static final String PRIORITY_FIELD = "Prio";
+  private static final String HIGH_PRIORITY = "HIGH";
+  private static final String PRIORITY_HIGH_FILTER_NAME = "Priority High Filter";
+  private static final String FILTER_OPERATOR_POLICY_KEY = Variable.FILTER_OPERATOR_POLICY.getKey();
+
+  private NewDashboardPage newDashboardPage;
+
+  @BeforeEach
+  public void setupTest() {
+    super.setup();
+    login(TestAccount.ADMIN_USER);
+    redirectToRelativeLink(createTestingTasksUrl);
+    redirectToNewDashBoard();
+    newDashboardPage = new NewDashboardPage();
+  }
+
+  @AfterEach
+  public void resetGlobalOperatorPolicy() {
+    updateGlobalVariable(FILTER_OPERATOR_POLICY_KEY, "TODAY,YESTERDAY,IS,IS_NOT,BEFORE,AFTER,BETWEEN,NOT_BETWEEN,CURRENT,LAST,NEXT,EMPTY,NOT_EMPTY,CONTAINS,NOT_CONTAINS,IN,NOT_IN,START_WITH,NOT_START_WITH,END_WITH,NOT_END_WITH,CURRENT_USER_CAN_WORK_ON,CURRENT_USER,NO_CATEGORY,EQUAL,NOT_EQUAL,LESS,LESS_OR_EQUAL,GREATER,GREATER_OR_EQUAL");
+  }
+
+  @Test
+  public void testGlobalDisabledOperatorIsHiddenInComplexFilterUsage() {
+    setGlobalOperatorEnabled(CONTAINS_KEY, false);
+
+    TaskWidgetNewDashBoardPage taskWidget = newDashboardPage.selectTaskWidget(YOUR_TASKS_WIDGET);
+    taskWidget.expand().shouldHave(sizeGreaterThanOrEqual(1));
+    taskWidget.openFilterWidget();
+    taskWidget.addFilter("Name", null);
+
+    assertThat(taskWidget.isOperatorOptionAvailableForFilterField("Name", FilterOperator.CONTAINS.getValue()))
+        .isFalse();
+  }
+
+  @Test
+  public void testDisabledInOperatorPrunesSessionFilters() {
+    TaskWidgetNewDashBoardPage taskWidget = newDashboardPage.selectTaskWidget(YOUR_TASKS_WIDGET);
+    taskWidget.expand().shouldHave(sizeGreaterThanOrEqual(1));
+    taskWidget.openFilterWidget();
+    taskWidget.addFilter(PRIORITY_FIELD, null);
+    taskWidget.selectPriorityFilterValue(HIGH_PRIORITY);
+    taskWidget.applyFilter();
+
+    setGlobalOperatorEnabled(IN_KEY, false);
+
+    taskWidget = newDashboardPage.selectTaskWidget(YOUR_TASKS_WIDGET);
+    taskWidget.expand().shouldHave(sizeGreaterThanOrEqual(1));
+    taskWidget.openFilterWidget();
+    assertThat(taskWidget.getNumberOfFilter()).isEqualTo(0);
+  }
+
+  @Test
+  public void testDisabledInOperatorPrunesSavedFilterOnLoad() {
+    TaskWidgetNewDashBoardPage taskWidget = newDashboardPage.selectTaskWidget(YOUR_TASKS_WIDGET);
+    taskWidget.expand().shouldHave(sizeGreaterThanOrEqual(1));
+    taskWidget.openFilterWidget();
+    taskWidget.addFilter(PRIORITY_FIELD, null);
+    taskWidget.selectPriorityFilterValue(HIGH_PRIORITY);
+    taskWidget.saveFilter(PRIORITY_HIGH_FILTER_NAME);
+    taskWidget.applyFilter();
+
+    setGlobalOperatorEnabled(IN_KEY, false);
+
+    taskWidget = newDashboardPage.selectTaskWidget(YOUR_TASKS_WIDGET);
+    taskWidget.expand().shouldHave(sizeGreaterThanOrEqual(1));
+    taskWidget.openFilterWidget();
+    taskWidget.selectSavedFilter(PRIORITY_HIGH_FILTER_NAME);
+    taskWidget.applyFilter();
+
+    taskWidget.openFilterWidget();
+    assertThat(taskWidget.getNumberOfFilter()).isEqualTo(0);
+  }
+
+  @Test
+  public void testReEnableOperatorMakesItAvailableAgain() {
+    setGlobalOperatorEnabled(CONTAINS_KEY, false);
+
+    TaskWidgetNewDashBoardPage taskWidget = newDashboardPage.selectTaskWidget(YOUR_TASKS_WIDGET);
+    taskWidget.expand().shouldHave(sizeGreaterThanOrEqual(1));
+    taskWidget.openFilterWidget();
+    taskWidget.addFilter("Name", null);
+    assertThat(taskWidget.isOperatorOptionAvailableForFilterField("Name", FilterOperator.CONTAINS.getValue()))
+        .isFalse();
+
+    setGlobalOperatorEnabled(CONTAINS_KEY, true);
+
+    taskWidget = newDashboardPage.selectTaskWidget(YOUR_TASKS_WIDGET);
+    taskWidget.expand().shouldHave(sizeGreaterThanOrEqual(1));
+    taskWidget.openFilterWidget();
+    taskWidget.addFilter("Name", null);
+    assertThat(taskWidget.isOperatorOptionAvailableForFilterField("Name", FilterOperator.CONTAINS.getValue()))
+        .isTrue();
+    
+
+  }
+
+  private void setGlobalOperatorEnabled(String operatorKey, boolean shouldBeSelected) {
+    redirectToNewDashBoard();
+    newDashboardPage = new NewDashboardPage();
+
+    AdminSettingsPage adminSettingsPage = newDashboardPage.openAdminSettings();
+    adminSettingsPage.updateGlobalMultiSelectionItem(FILTER_OPERATOR_POLICY_KEY, operatorKey, shouldBeSelected);
+    adminSettingsPage.closeConfirmationDialog();
+
+    redirectToNewDashBoard();
+    newDashboardPage = new NewDashboardPage();
+  }
+
+
+}

--- a/AxonIvyPortal/portal/cms/cms.yaml
+++ b/AxonIvyPortal/portal/cms/cms.yaml
@@ -669,8 +669,6 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
-    operators: Operators
-    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms.yaml
+++ b/AxonIvyPortal/portal/cms/cms.yaml
@@ -166,6 +166,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Set URL to download Axon Ivy mobile app on Apple Store.
       BaseQRCodeUrl: Set Base URL for QR code to display.
       GooglePlayURL: Set URL to download Axon Ivy mobile app on Google Play.
+      DashboardFilterOperatorPolicy: Unchecked operators are disabled globally.
       behaviourWhenClickingOnLineInCaseList: Toggle between accessing case details or business details when clicking on a case in the case widget on the dashboard, global search, related cases, and process widget in combined mode.
       behaviourWhenClickingOnLineInTaskList: For switch behaviours (run the task or access task details) when clicking on a line in task list, task widget of dashboard and related tasks  in case details page.
       chatMaxConnection: 'The set number controls the amount of tabs allowed with active chat. If more tabs are opened, the chat will be disabled in inactive tabs. Allowed values between 1-5 '
@@ -589,6 +590,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     EmptyFilterMessage: No widget filter found
     Filter:
       FilterOptionHeader: Filter options
+      FilterOptionHeaderTooltip: Some filter fields and operators may be disabled by your administrator. Filters using disabled fields or operators will be automatically removed. Please contact your administrator for more information.
       FilterPanelHeader: Filter panel
       ManageWidgetFilterHeader: Widget filter management
       NotFound: No filter found
@@ -667,6 +669,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
+    operators: Operators
+    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms_de.yaml
+++ b/AxonIvyPortal/portal/cms/cms_de.yaml
@@ -928,8 +928,6 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Sie haben keine Berechtigung, Dashboards zu sehen.
     noWidget: Es sind aktuell keine Widgets auf diesem Dashboard vorhanden
     numberPattern: Zahlen-Muster
-    operators: Operatoren
-    operatorPolicyTooltip: Wenn Operatoren vom Administrator global deaktiviert sind, können sie hier nicht aktiviert werden. Der Filter eines Felds kann nicht aktiviert werden, wenn alle Operatoren global deaktiviert sind.
     preview: Vorschau
     processList: Prozessliste
     processListIntroduction: Dieses Widget zeigt verfügbare Prozessstarts an. Sie haben die Möglichkeit, unterschiedliche Formate zu wählen

--- a/AxonIvyPortal/portal/cms/cms_de.yaml
+++ b/AxonIvyPortal/portal/cms/cms_de.yaml
@@ -219,6 +219,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Legen Sie die URL für den Download der Axon Ivy Mobile App im Apple Store fest.
       ApplicationName: Der Name der Anwendung, der auf dem Seitentitel angezeigt werden soll.
       BaseQRCodeUrl: Legen Sie die Basis-URL für den anzuzeigenden QR-Code fest.
+      DashboardFilterOperatorPolicy: Nicht ausgewählte Operatoren werden global deaktiviert.
       DefaultThemeMode: Der Standardthemenmodus der Anwendung
       EnableSwitchThemeModeButton: Setzen Sie diesen Wert auf true, um die Schaltfläche "Thema wechseln" zu aktivieren.
       GlobalSearchScopeCategoriesNote: Festlegung der Typen, nach denen bei der globalen Suche gesucht werden soll
@@ -791,6 +792,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Dieses Widget kann eine externe Webseite anzeigen.
     Filter:
       FilterOptionHeader: Filter-Optionen
+      FilterOptionHeaderTooltip: Einige Filterfelder und Operatoren wurden möglicherweise von Ihrem Administrator deaktiviert. Filter, die deaktivierte Felder oder Operatoren verwenden, werden automatisch entfernt. Bitte wenden Sie sich an Ihren Administrator für weitere Informationen.
       FilterPanelHeader: Filterbereich
       ManageWidgetFilterHeader: Widget-Filter-Verwaltung
       NotFound: Kein Filter gefunden
@@ -926,6 +928,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Sie haben keine Berechtigung, Dashboards zu sehen.
     noWidget: Es sind aktuell keine Widgets auf diesem Dashboard vorhanden
     numberPattern: Zahlen-Muster
+    operators: Operatoren
+    operatorPolicyTooltip: Wenn Operatoren vom Administrator global deaktiviert sind, können sie hier nicht aktiviert werden. Der Filter eines Felds kann nicht aktiviert werden, wenn alle Operatoren global deaktiviert sind.
     preview: Vorschau
     processList: Prozessliste
     processListIntroduction: Dieses Widget zeigt verfügbare Prozessstarts an. Sie haben die Möglichkeit, unterschiedliche Formate zu wählen

--- a/AxonIvyPortal/portal/cms/cms_en.yaml
+++ b/AxonIvyPortal/portal/cms/cms_en.yaml
@@ -219,6 +219,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Set URL to download Axon Ivy mobile app on Apple Store.
       ApplicationName: The application name that will be displayed on the page title.
       BaseQRCodeUrl: Set Base URL for QR code to display.
+      DashboardFilterOperatorPolicy: Unchecked operators are disabled globally.
       DefaultThemeMode: The default theme mode of the application
       EnableSwitchThemeModeButton: Set to true to enable the switch theme button.
       GlobalSearchScopeCategoriesNote: Defining the types that the global search will search for
@@ -789,6 +790,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: This widget can display an external webpage.
     Filter:
       FilterOptionHeader: Filter options
+      FilterOptionHeaderTooltip: Some filter fields and operators may be disabled by your administrator. Filters using disabled fields or operators will be automatically removed. Please contact your administrator for more information.
       FilterPanelHeader: Filter panel
       ManageWidgetFilterHeader: Widget filter management
       NotFound: No filter found
@@ -924,6 +926,9 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
+    operators: Operators
+    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
+    operatorPolicyInvalid: 'Some selected operators are disabled by global configuration. Please review: {0}'
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms_en.yaml
+++ b/AxonIvyPortal/portal/cms/cms_en.yaml
@@ -926,9 +926,6 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
-    operators: Operators
-    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
-    operatorPolicyInvalid: 'Some selected operators are disabled by global configuration. Please review: {0}'
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms_es.yaml
+++ b/AxonIvyPortal/portal/cms/cms_es.yaml
@@ -928,8 +928,6 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: No tienes permisos para ver los dashboards.
     noWidget: No hay widgets para este tablero
     numberPattern: Patrón de números
-    operators: Operadores
-    operatorPolicyTooltip: Si los operadores están deshabilitados globalmente por el administrador, no pueden habilitarse aquí. El filtro de un campo no puede habilitarse cuando todos los operadores están deshabilitados globalmente.
     preview: Vista previa
     processList: Lista de procesos
     processListIntroduction: Este widget muestra los inicios de procesos disponibles. Tiene la posibilidad de elegir diferentes formatos

--- a/AxonIvyPortal/portal/cms/cms_es.yaml
+++ b/AxonIvyPortal/portal/cms/cms_es.yaml
@@ -219,6 +219,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Establezca la URL para descargar la aplicación móvil Axon Ivy en Apple Store.
       ApplicationName: El nombre de la aplicación que se mostrará en el título de la página.
       BaseQRCodeUrl: Establezca la URL base para mostrar el código QR.
+      DashboardFilterOperatorPolicy: Los operadores no marcados se deshabilitan globalmente.
       DefaultThemeMode: El modo de tema por defecto de la aplicación
       EnableSwitchThemeModeButton: Establecer en true para habilitar el botón de cambio de tema.
       GlobalSearchScopeCategoriesNote: Definición de los tipos que buscará la búsqueda global
@@ -791,6 +792,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Este widget puede mostrar una página web externa.
     Filter:
       FilterOptionHeader: Opciones de filtro
+      FilterOptionHeaderTooltip: Algunos campos de filtro y operadores pueden estar deshabilitados por su administrador. Los filtros que utilicen campos u operadores deshabilitados se eliminarán automáticamente. Comuníquese con su administrador para obtener más información.
       FilterPanelHeader: Panel de filtro
       ManageWidgetFilterHeader: Gestión de filtros de widgets
       NotFound: No se ha encontrado ningún filtro
@@ -926,6 +928,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: No tienes permisos para ver los dashboards.
     noWidget: No hay widgets para este tablero
     numberPattern: Patrón de números
+    operators: Operadores
+    operatorPolicyTooltip: Si los operadores están deshabilitados globalmente por el administrador, no pueden habilitarse aquí. El filtro de un campo no puede habilitarse cuando todos los operadores están deshabilitados globalmente.
     preview: Vista previa
     processList: Lista de procesos
     processListIntroduction: Este widget muestra los inicios de procesos disponibles. Tiene la posibilidad de elegir diferentes formatos

--- a/AxonIvyPortal/portal/cms/cms_fr.yaml
+++ b/AxonIvyPortal/portal/cms/cms_fr.yaml
@@ -219,6 +219,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Définir l'URL pour télécharger l'application mobile Axon Ivy sur l'Apple Store.
       ApplicationName: Le nom de l'application qui sera affiché dans le titre de la page.
       BaseQRCodeUrl: Définir l'URL de base du code QR à afficher.
+      DashboardFilterOperatorPolicy: Les opérateurs décochés sont désactivés globalement.
       DefaultThemeMode: Le mode de thème par défaut de l'application
       EnableSwitchThemeModeButton: Défini à true pour activer le bouton de changement de thème.
       GlobalSearchScopeCategoriesNote: Définition des types recherchés par la recherche globale
@@ -791,6 +792,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Ce widget peut afficher une page web externe.
     Filter:
       FilterOptionHeader: Options de filtre
+      FilterOptionHeaderTooltip: Certains champs de filtre et opérateurs peuvent être désactivés par votre administrateur. Les filtres utilisant des champs ou des opérateurs désactivés seront automatiquement supprimés. Veuillez contacter votre administrateur pour plus d'informations.
       FilterPanelHeader: Panneau de filtre
       ManageWidgetFilterHeader: Gestion des filtres des widgets
       NotFound: Aucun filtre trouvé
@@ -926,6 +928,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Vous n'avez pas les permissions pour voir les tableaux de bord.
     noWidget: Il n'y a pas de widgets fournis pour ce tableau de bord.
     numberPattern: Modèle de numéro
+    operators: Opérateurs
+    operatorPolicyTooltip: Si les opérateurs sont désactivés globalement par l'administrateur, ils ne peuvent pas être activés ici. Le filtre d'un champ ne peut pas être activé lorsque tous les opérateurs sont désactivés globalement.
     preview: Aperçu
     processList: Liste des processus
     processListIntroduction: Ce widget montre les démarrages de processus disponibles. Vous avez la possibilité de choisir différents formats

--- a/AxonIvyPortal/portal/cms/cms_fr.yaml
+++ b/AxonIvyPortal/portal/cms/cms_fr.yaml
@@ -928,8 +928,6 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Vous n'avez pas les permissions pour voir les tableaux de bord.
     noWidget: Il n'y a pas de widgets fournis pour ce tableau de bord.
     numberPattern: Modèle de numéro
-    operators: Opérateurs
-    operatorPolicyTooltip: Si les opérateurs sont désactivés globalement par l'administrateur, ils ne peuvent pas être activés ici. Le filtre d'un champ ne peut pas être activé lorsque tous les opérateurs sont désactivés globalement.
     preview: Aperçu
     processList: Liste des processus
     processListIntroduction: Ce widget montre les démarrages de processus disponibles. Vous avez la possibilité de choisir différents formats

--- a/AxonIvyPortal/portal/cms/cms_ja.yaml
+++ b/AxonIvyPortal/portal/cms/cms_ja.yaml
@@ -927,8 +927,6 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: ダッシュボードを表示する権限がありません。
     noWidget: このダッシュボードにはウィジェットが用意されていません
     numberPattern: 番号パターン
-    operators: オペレーター
-    operatorPolicyTooltip: オペレーターが管理者によってグローバルに無効化されている場合、ここで有効化することはできません。すべてのオペレーターがグローバルに無効化されている場合、フィールドのフィルターを有効化することはできません。
     preview: プレビュー
     processList: プロセスリスト
     processListIntroduction: このウィジェットには、利用可能なプロセス開始が表示されます。さまざまな形式を選択できます。

--- a/AxonIvyPortal/portal/cms/cms_ja.yaml
+++ b/AxonIvyPortal/portal/cms/cms_ja.yaml
@@ -219,6 +219,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Apple Store で Axon Ivy モバイル アプリをダウンロードするための URL を設定します。
       ApplicationName: ページタイトルに表示されるアプリケーション名。
       BaseQRCodeUrl: 表示するQRコードのベースURLを設定します。
+      DashboardFilterOperatorPolicy: 未選択の演算子はグローバルで無効になります。
       DefaultThemeMode: アプリケーションのテーマモードの初期値
       EnableDocumentPreview: ドキュメントのプレビューを有効にするには true に設定してください。（プレビュー可能なファイルの種類：pdf、png、txt、log）
       EnableSwitchThemeModeButton: テーマ切り替えボタンを有効にするには true に設定してください。
@@ -790,6 +791,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: このウィジェットは外部Webページを表示できます。
     Filter:
       FilterOptionHeader: フィルターオプション
+      FilterOptionHeaderTooltip: 一部のフィルターフィールドや演算子は管理者によって無効化されている場合があります。無効なフィールドまたは演算子を使用しているフィルターは自動的に削除されます。詳細については管理者にお問い合わせください。
       FilterPanelHeader: フィルターパネル
       ManageWidgetFilterHeader: ウィジェットフィルター管理
       NotFound: フィルターが見つかりません
@@ -925,6 +927,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: ダッシュボードを表示する権限がありません。
     noWidget: このダッシュボードにはウィジェットが用意されていません
     numberPattern: 番号パターン
+    operators: オペレーター
+    operatorPolicyTooltip: オペレーターが管理者によってグローバルに無効化されている場合、ここで有効化することはできません。すべてのオペレーターがグローバルに無効化されている場合、フィールドのフィルターを有効化することはできません。
     preview: プレビュー
     processList: プロセスリスト
     processListIntroduction: このウィジェットには、利用可能なプロセス開始が表示されます。さまざまな形式を選択できます。

--- a/AxonIvyPortal/portal/config/variables.yaml
+++ b/AxonIvyPortal/portal/config/variables.yaml
@@ -62,6 +62,9 @@ Variables:
       # You can customize the name and icon of the main menu entry for Portal dashboards via this JSON file.
       # [file: json]
       MainMenuEntry: ""
+    # Configure enabled operators for complex filters as comma-separated enum names.
+    ComplexFilter:
+      Operators: TODAY,YESTERDAY,IS,IS_NOT,BEFORE,AFTER,BETWEEN,NOT_BETWEEN,CURRENT,LAST,NEXT,EMPTY,NOT_EMPTY,CONTAINS,NOT_CONTAINS,IN,NOT_IN,START_WITH,NOT_START_WITH,END_WITH,NOT_END_WITH,CURRENT_USER_CAN_WORK_ON,CURRENT_USER,NO_CATEGORY,EQUAL,NOT_EQUAL,LESS,LESS_OR_EQUAL,GREATER,GREATER_OR_EQUAL
     Processes:
       # The standard setting of view mode in the process list.
       # [enum: COMPACT, IMAGE, GRID]

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/GlobalSetting.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/GlobalSetting.java
@@ -13,6 +13,7 @@ import com.axonivy.portal.enums.SearchScopeCaseField;
 import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.enums.SidebarMode;
 import com.axonivy.portal.enums.ThemeMode;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -126,6 +127,7 @@ public class GlobalSetting extends AbstractConfiguration {
       case GlobalSearchScopeCategory castObject -> castObject.getLabel();
       case DelegationAppendOption castObject -> castObject.getLabel();
       case SidebarMode castObject -> castObject.getLabel();
+      case FilterOperator castObject -> castObject.getLabel();
       default -> (String) object;
     };
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/AbstractColumn.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/AbstractColumn.java
@@ -497,7 +497,7 @@ public abstract class AbstractColumn implements Serializable {
   
   @JsonIgnore
   public boolean getHasCmsValues() {
-    return hasCmsValues;
+    return Boolean.TRUE.equals(hasCmsValues);
   }
   
   public void setHasCmsValues(Boolean hasCmsValues) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/enums/GlobalVariable.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/enums/GlobalVariable.java
@@ -16,6 +16,7 @@ import com.axonivy.portal.enums.SearchScopeCaseField;
 import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.enums.SidebarMode;
 import com.axonivy.portal.enums.ThemeMode;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 
 import ch.addon.portal.generic.userprofile.homepage.HomepageType;
 import ch.ivy.addon.portalkit.document.DocumentExtensionConstants;
@@ -97,7 +98,9 @@ public enum GlobalVariable {
   ENABLE_PINNED_CASE("Portal.Cases.EnablePinnedCase",GlobalVariableType.SELECTION, Option.FALSE.toString(),"enablePinCase"),
   ALLOW_KEYBOARD_SHORTCUTS_CONFIGURATION(
       "Portal.Accessibility.AllowKeyboardShortcutsConfiguration", GlobalVariableType.SELECTION, Option.TRUE.toString(), "allowKeyboardShortcutsConfiguration"),
-  SIDEBAR_MODE("Portal.Sidebar.Mode", GlobalVariableType.EXTERNAL_SELECTION, SidebarMode.HOVER.name(), "sidebarMode", getSidebarModes());
+  SIDEBAR_MODE("Portal.Sidebar.Mode", GlobalVariableType.EXTERNAL_SELECTION, SidebarMode.HOVER.name(), "sidebarMode", getSidebarModes()),
+  FILTER_OPERATOR_POLICY("Portal.ComplexFilter.Operators", GlobalVariableType.MULTI_EXTERNAL_SELECTIONS,
+      getFilterOperatorOptions(), "DashboardFilterOperatorPolicy", getFilterOperatorOptions());
 
   private String key;
   private GlobalVariableType type;
@@ -304,6 +307,14 @@ public enum GlobalVariable {
     Map<String, Object> result = new HashMap<>();
     for (SidebarMode mode : SidebarMode.values()) {
       result.put(mode.name(), mode);
+    }
+    return result;
+  }
+
+  private static Map<String, Object> getFilterOperatorOptions() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    for (FilterOperator operator : FilterOperator.values()) {
+      result.put(operator.name(), operator);
     }
     return result;
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/WidgetFilterService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/WidgetFilterService.java
@@ -15,6 +15,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
+
 import ch.ivy.addon.portalkit.bean.WidgetFilterHelperBean;
 import ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget;
 import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
@@ -94,7 +96,9 @@ public class WidgetFilterService extends JsonConfigurationService<WidgetFilterMo
     }
 
     filter.setUserFilters(widget.getUserFilters().stream().filter(Objects::nonNull)
-        .filter(userFilter -> StringUtils.isNotBlank(userFilter.getField())).collect(Collectors.toList()));
+        .filter(userFilter -> StringUtils.isNotBlank(userFilter.getField()))
+        .filter(GlobalOperatorPolicyService.getInstance()::isFilterAllowedByGlobalPolicy)
+        .collect(Collectors.toList()));
   }
   
   public void prepareSaveTaskFilter(WidgetFilterModel filter, TaskDashboardWidget widget) {
@@ -103,11 +107,14 @@ public class WidgetFilterService extends JsonConfigurationService<WidgetFilterMo
     }
 
     filter.setUserFilters(widget.getUserFilters().stream().filter(Objects::nonNull)
-        .filter(userFilter -> StringUtils.isNotBlank(userFilter.getField())).collect(Collectors.toList()));
+        .filter(userFilter -> StringUtils.isNotBlank(userFilter.getField()))
+        .filter(GlobalOperatorPolicyService.getInstance()::isFilterAllowedByGlobalPolicy)
+        .collect(Collectors.toList()));
   }
 
 
   public void applyUserFilterFromSession(DashboardWidget widget) {
+    removeDisabledPredefinedFilters(widget);
     var selectedFilterObject = Ivy.session().getAttribute(buildWidgetKey(widget.getId(), widget.getType()));
     var userFilterCollection = BusinessEntityConverter.jsonValueToEntity(String.valueOf(selectedFilterObject), UserFilterCollection.class);
     if (userFilterCollection == null) {
@@ -328,12 +335,30 @@ public class WidgetFilterService extends JsonConfigurationService<WidgetFilterMo
 
   public static void removeDisabledFilters(TaskDashboardWidget widget) {
     List<String> nonFilterableColumns = getNonFilterableColumns(widget).stream().map(ColumnModel::getField).toList();
-    widget.getUserFilters().removeIf(userFilter -> nonFilterableColumns.contains(userFilter.getField()));
+    widget.setUserFilters(CollectionUtils.emptyIfNull(widget.getUserFilters()).stream()
+        .filter(Objects::nonNull)
+        .filter(userFilter -> StringUtils.isNotBlank(userFilter.getField()))
+        .filter(userFilter -> !nonFilterableColumns.contains(userFilter.getField()))
+        .filter(GlobalOperatorPolicyService.getInstance()::isFilterAllowedByGlobalPolicy)
+        .collect(Collectors.toList()));
   }
 
   public static void removeDisabledFilters(CaseDashboardWidget widget) {
     List<String> nonFilterableColumns = getNonFilterableColumns(widget).stream().map(ColumnModel::getField).toList();
-    widget.getUserFilters().removeIf(userFilter -> nonFilterableColumns.contains(userFilter.getField()));
+    widget.setUserFilters(CollectionUtils.emptyIfNull(widget.getUserFilters()).stream()
+        .filter(Objects::nonNull)
+        .filter(userFilter -> StringUtils.isNotBlank(userFilter.getField()))
+        .filter(userFilter -> !nonFilterableColumns.contains(userFilter.getField()))
+        .filter(GlobalOperatorPolicyService.getInstance()::isFilterAllowedByGlobalPolicy)
+        .collect(Collectors.toList()));
+  }
+
+  public static void removeDisabledPredefinedFilters(DashboardWidget widget) {
+    if (widget instanceof TaskDashboardWidget taskWidget) {
+      taskWidget.setFilters(GlobalOperatorPolicyService.getInstance().keepGloballyEnabledFilters(taskWidget.getFilters()));
+    } else if (widget instanceof CaseDashboardWidget caseWidget) {
+      caseWidget.setFilters(GlobalOperatorPolicyService.getInstance().keepGloballyEnabledFilters(caseWidget.getFilters()));
+    }
   }
 
   private void removeDisabledUserFilters(WidgetFilterModel model, DashboardWidgetType widgetType, List<ColumnModel> nonFilterableColumns) {
@@ -341,8 +366,10 @@ public class WidgetFilterService extends JsonConfigurationService<WidgetFilterMo
       return;
     }
     model.setUserFilters(CollectionUtils.emptyIfNull(model.getUserFilters()).stream()
+        .filter(Objects::nonNull)
         .filter(f -> StringUtils.isNotBlank(f.getField()))
         .filter(f -> nonFilterableColumns.stream().noneMatch(col -> Strings.CS.equals(col.getField(), f.getField())))
+        .filter(GlobalOperatorPolicyService.getInstance()::isFilterAllowedByGlobalPolicy)
         .collect(Collectors.toList()));
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetApplicationFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetApplicationFilterBean.java
@@ -9,8 +9,11 @@ import javax.faces.bean.ViewScoped;
 
 import org.apache.commons.collections4.CollectionUtils;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 import ch.ivy.addon.portalkit.util.ListUtilities;
 import ch.ivyteam.ivy.application.IApplication;
@@ -23,9 +26,14 @@ public class WidgetApplicationFilterBean implements Serializable {
 
   private static final long serialVersionUID = 4458514225804204212L;
 
-  private static List<FilterOperator> operators = FilterOperator.APPLICATION_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
   private List<String> applications;
   private String applicationString;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.APPLICATION_OPERATORS.stream().toList());
+  }
 
   public void init(DashboardFilter filter) {
     this.applications = ListUtilities.transformList(IApplicationRepository.of(ISecurityContext.current()).all(),
@@ -36,7 +44,7 @@ public class WidgetApplicationFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public List<String> getApplications() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCategoryFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCategoryFilterBean.java
@@ -11,8 +11,11 @@ import javax.faces.bean.ViewScoped;
 import org.apache.commons.collections4.CollectionUtils;
 import org.primefaces.model.CheckboxTreeNode;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 import ch.ivy.addon.portalkit.bo.CategoryNode;
 import ch.ivy.addon.portalkit.dto.dashboard.DashboardWidget;
@@ -27,11 +30,16 @@ public class WidgetCategoryFilterBean implements Serializable {
 
   private static final long serialVersionUID = 5886200209828694569L;
 
-  private static List<FilterOperator> operators = FilterOperator.CATEGORY_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
 
   private CheckboxTreeNode<CategoryNode> categoryTree;
   private CheckboxTreeNode<CategoryNode>[] selectedCategoryNodes;
   private String selectedCategoriesString;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.CATEGORY_OPERATORS.stream().toList());
+  }
 
   public void init(DashboardFilter filter, DashboardWidget widget) {
     loadCategories(filter, widget);
@@ -43,7 +51,7 @@ public class WidgetCategoryFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public void onChangeOperator(DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCreatorFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCreatorFilterBean.java
@@ -14,9 +14,12 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.primefaces.event.SelectEvent;
 import org.primefaces.event.UnselectEvent;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -25,9 +28,14 @@ public class WidgetCreatorFilterBean implements Serializable {
   private static final long serialVersionUID = -2641889624945089060L;
   public static final String FILTER = "filter";
 
-  private static List<FilterOperator> operators = FilterOperator.CREATOR_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
 
   private List<SecurityMemberDTO> selectedCreators;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.CREATOR_OPERATORS.stream().toList());
+  }
 
   public void init(DashboardFilter filter) {
     selectedCreators = new ArrayList<>();
@@ -37,7 +45,7 @@ public class WidgetCreatorFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public void onChangeOperator(DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetDateFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetDateFilterBean.java
@@ -8,9 +8,12 @@ import java.util.Optional;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.axonivy.portal.enums.dashboard.filter.FilterPeriodType;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterFieldFactory;
 import com.axonivy.portal.util.filter.field.TaskFilterFieldFactory;
 
@@ -26,8 +29,8 @@ public class WidgetDateFilterBean implements Serializable {
 
   private static final long serialVersionUID = 4356531402161360729L;
 
-  private static List<FilterOperator> operators = FilterOperator.DATE_OPERATORS.stream().toList();
-  private static List<FilterOperator> createdDateOperators = FilterOperator.CREATED_DATE_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
+  private List<FilterOperator> resolvedCreatedDateOperators;
 
   private static FilterPeriodType[] filterPeriodTypes = FilterPeriodType.values();
   private static List<FilterPeriodType> currentFilterPeriodTypes = FilterPeriodType.PERIOD_TYPES_FOR_CURRENT_OPERATOR
@@ -35,8 +38,14 @@ public class WidgetDateFilterBean implements Serializable {
 
   private static SimpleDateFormat formatter = new SimpleDateFormat(DashboardFilter.DATE_FORMAT);
 
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.DATE_OPERATORS.stream().toList());
+    resolvedCreatedDateOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.CREATED_DATE_OPERATORS.stream().toList());
+  }
+
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public FilterPeriodType[] getFilterPeriodTypes() {
@@ -92,6 +101,6 @@ public class WidgetDateFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getCreatedDateOperators() {
-    return createdDateOperators;
+    return resolvedCreatedDateOperators;
   }
 }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetIdFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetIdFilterBean.java
@@ -6,8 +6,11 @@ import java.util.List;
 import javax.faces.bean.ManagedBean;
 import javax.faces.view.ViewScoped;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -15,10 +18,15 @@ public class WidgetIdFilterBean implements Serializable {
 
   private static final long serialVersionUID = 4671032185665650209L;
 
-  private static List<FilterOperator> operators = FilterOperator.ID_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.ID_OPERATORS.stream().toList());
+  }
 
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public void onChangeOperator(@SuppressWarnings("unused") DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetNumberFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetNumberFilterBean.java
@@ -15,8 +15,11 @@ import java.util.Optional;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -24,12 +27,17 @@ public class WidgetNumberFilterBean implements Serializable {
 
   private static final long serialVersionUID = 6088715427600445713L;
 
-  private static List<FilterOperator> operators = FilterOperator.NUMBER_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
   private static List<FilterOperator> SINGLE_FILTER_OPERATORS = Arrays.asList(EQUAL, NOT_EQUAL, LESS, LESS_OR_EQUAL,
       GREATER, GREATER_OR_EQUAL);
 
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.NUMBER_OPERATORS.stream().toList());
+  }
+
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public boolean renderSingleNumberFilter(DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetPriorityFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetPriorityFilterBean.java
@@ -9,8 +9,11 @@ import java.util.List;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.workflow.WorkflowPriority;
@@ -21,11 +24,16 @@ public class WidgetPriorityFilterBean implements Serializable {
 
   private static final long serialVersionUID = 5710087841257652703L;
 
-  private static List<FilterOperator> priorityOperators = FilterOperator.PRIORITY_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedPriorityOperators;
   private static final String TASK_PRIORITY_CMS_PATH = "/ch.ivy.addon.portalkit.ui.jsf/taskPriority/";
 
   private List<String> priorities;
   private String prioritiesString;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedPriorityOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.PRIORITY_OPERATORS.stream().toList());
+  }
 
   public void init(DashboardFilter filter) {
     List<WorkflowPriority> wfPriority = Arrays.asList(WorkflowPriority.EXCEPTION, WorkflowPriority.HIGH,
@@ -36,7 +44,7 @@ public class WidgetPriorityFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getPriorityOperators() {
-    return priorityOperators;
+    return resolvedPriorityOperators;
   }
 
   public List<String> getPriorities() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetResponsibleFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetResponsibleFilterBean.java
@@ -14,9 +14,12 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.primefaces.event.SelectEvent;
 import org.primefaces.event.UnselectEvent;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -25,9 +28,14 @@ public class WidgetResponsibleFilterBean implements Serializable {
   private static final long serialVersionUID = -2641889624945089060L;
   public static final String FILTER = "filter";
 
-  private static List<FilterOperator> operators = FilterOperator.RESPONSIBLE_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
 
   private List<SecurityMemberDTO> selectedResponsibles;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.RESPONSIBLE_OPERATORS.stream().toList());
+  }
 
   public void init(DashboardFilter filter) {
     selectedResponsibles = new ArrayList<>();
@@ -37,7 +45,7 @@ public class WidgetResponsibleFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public void onChangeOperator(DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetStateFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetStateFilterBean.java
@@ -8,8 +8,11 @@ import javax.faces.bean.ViewScoped;
 
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 import ch.ivy.addon.portalkit.dto.dashboard.DashboardWidget;
 import ch.ivy.addon.portalkit.enums.DashboardWidgetType;
@@ -23,10 +26,15 @@ public class WidgetStateFilterBean implements Serializable {
 
   private static final long serialVersionUID = -8191354257458990196L;
 
-  private static List<FilterOperator> stateOperators = FilterOperator.STATE_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedStateOperators;
 
   private List<String> states;
   private String statesString;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedStateOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.STATE_OPERATORS.stream().toList());
+  }
 
   public void init(DashboardFilter filter, DashboardWidget widget) {
     if (DashboardWidgetType.TASK == widget.getType()) {
@@ -46,7 +54,7 @@ public class WidgetStateFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getStateOperators() {
-    return stateOperators;
+    return resolvedStateOperators;
   }
 
   public List<String> getStates() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
@@ -1,15 +1,16 @@
 package com.axonivy.portal.bean.dashboard;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.caze.custom.CaseFilterFieldCustomString;
 import com.axonivy.portal.util.filter.field.task.custom.caze.TaskFilterCaseFieldCustomString;
 
@@ -21,15 +22,21 @@ public class WidgetTextFilterBean implements Serializable {
 
   private static final long serialVersionUID = 3218284115015773931L;
 
-  private static List<FilterOperator> operators = FilterOperator.TEXT_OPERATORS.stream().toList();
-  private static List<FilterOperator> operatorsForCustomFieldWithCms = Collections.unmodifiableSet(EnumSet.of(FilterOperator.CONTAINS)).stream().toList();
+  private List<FilterOperator> resolvedOperators;
+  private List<FilterOperator> resolvedOperatorsForCustomFieldWithCms;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.TEXT_OPERATORS.stream().toList());
+    resolvedOperatorsForCustomFieldWithCms = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(List.of(FilterOperator.CONTAINS));
+  }
 
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
   
   public List<FilterOperator> getOperatorsForCustomFieldWithCms() {
-    return operatorsForCustomFieldWithCms;
+    return resolvedOperatorsForCustomFieldWithCms;
   }
 
   public void onChangeOperator(@SuppressWarnings("unused") DashboardFilter filter) {
@@ -40,7 +47,7 @@ public class WidgetTextFilterBean implements Serializable {
       return false;
     }
 
-    for (FilterOperator operator : operators) {
+    for (FilterOperator operator : getOperators()) {
       if (operator == FilterOperator.EMPTY || operator == FilterOperator.NOT_EMPTY) {
         continue;
       }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetWorkerFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetWorkerFilterBean.java
@@ -14,9 +14,12 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.primefaces.event.SelectEvent;
 import org.primefaces.event.UnselectEvent;
 
+import javax.annotation.PostConstruct;
+
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -25,9 +28,14 @@ public class WidgetWorkerFilterBean implements Serializable {
   private static final long serialVersionUID = -2641889624945089060L;
   public static final String FILTER = "filter";
 
-  private static List<FilterOperator> operators = FilterOperator.WORKER_OPERATORS.stream().toList();
+  private List<FilterOperator> resolvedOperators;
 
   private List<SecurityMemberDTO> selectedWorkers;
+
+  @PostConstruct
+  public void initOperators() {
+    resolvedOperators = GlobalOperatorPolicyService.getInstance().keepGloballyEnabledOperators(FilterOperator.WORKER_OPERATORS.stream().toList());
+  }
 
   public void init(DashboardFilter filter) {
     selectedWorkers = new ArrayList<>();
@@ -37,7 +45,7 @@ public class WidgetWorkerFilterBean implements Serializable {
   }
 
   public List<FilterOperator> getOperators() {
-    return operators;
+    return resolvedOperators;
   }
 
   public void onChangeOperator(DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterField;
 import com.axonivy.portal.util.filter.field.FilterFieldFactory;
 import com.axonivy.portal.util.filter.field.caze.CaseFilterFieldCreator;
@@ -48,13 +49,15 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
   private void initFilterFields() {
     Set<String> disabledStandardFilterFieldNames = this.widget.getColumns().stream().filter(Objects::nonNull)
       .filter(column -> DashboardColumnType.STANDARD == column.getType())
-      .filter(column -> BooleanUtils.isFalse(column.getEnableFilter())).map(ColumnModel::getField)
+      .filter(column -> BooleanUtils.isFalse(column.getEnableFilter()))
+      .map(ColumnModel::getField)
       .collect(Collectors.toSet());
 
     this.filterFields = new ArrayList<>();
     this.filterFields.add(FilterFieldFactory.getDefaultFilterField());
     this.filterFields.addAll(FilterFieldFactory.getStandardFilterableFields(this.widget.getId()).stream()
-      .filter(field -> !disabledStandardFilterFieldNames.contains(field.getName()))
+      .filter(field -> !disabledStandardFilterFieldNames.contains(field.getName())
+                 && GlobalOperatorPolicyService.getInstance().hasAnyGloballyEnabledOperator(field))
       .collect(Collectors.toList()));
 
     // Remove Case Creator filter when the HideCaseCreator variable is enable.
@@ -65,6 +68,7 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
     updateFilterLabels();
     // Add custom fields which are selected by user.
     this.widget.getFilterableColumns().stream().filter(col -> col.getType() == DashboardColumnType.CUSTOM)
+        .filter(col -> GlobalOperatorPolicyService.getInstance().hasAnyGloballyEnabledOperator(col))
         .map(col -> FilterFieldFactory.findCustomFieldBy(col.getField())).filter(Objects::nonNull)
         .forEach(this.filterFields::add);
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
@@ -130,6 +130,7 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
 
     filter.setLabel(filterField.getLabel());
     filterField.addNewFilter(filter);
+    filter.setOperator(GlobalOperatorPolicyService.getInstance().getFirstEnabledOperator(filter.getField(), filter.getOperator()));
     initCustomFieldNumberPattern(filter, field, filterField);
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterField;
 import com.axonivy.portal.util.filter.field.FilterFieldFactory;
 import com.axonivy.portal.util.filter.field.TaskFilterFieldFactory;
@@ -50,18 +51,21 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
   private void initFilterFields() {
     Set<String> disabledStandardFilterFieldNames = this.widget.getColumns().stream().filter(Objects::nonNull)
       .filter(column -> DashboardColumnType.STANDARD == column.getType())
-      .filter(column -> BooleanUtils.isFalse(column.getEnableFilter())).map(ColumnModel::getField)
+      .filter(column -> BooleanUtils.isFalse(column.getEnableFilter()))
+      .map(ColumnModel::getField)
       .collect(Collectors.toSet());
 
     this.filterFields = new ArrayList<>();
     this.filterFields.add(TaskFilterFieldFactory.getDefaultFilterField());
     this.filterFields.addAll(TaskFilterFieldFactory.getStandardFilterableFields(this.widget.getId()).stream()
-      .filter(field -> !disabledStandardFilterFieldNames.contains(field.getName()))
+      .filter(field -> !disabledStandardFilterFieldNames.contains(field.getName())
+                 && GlobalOperatorPolicyService.getInstance().hasAnyGloballyEnabledOperator(field))
       .collect(Collectors.toList()));
 
     updateFilterLabels();
     // Add custom fields which are selected by user.
     this.widget.getFilterableColumns().stream().filter(column -> column.getType() != DashboardColumnType.STANDARD)
+        .filter(column -> GlobalOperatorPolicyService.getInstance().hasAnyGloballyEnabledOperator(column))
         .map(column -> TaskFilterFieldFactory.findBy(column.getField(), column.getType())).filter(Objects::nonNull)
         .forEach(this.filterFields::add);
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
@@ -129,6 +129,7 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
 
     filter.setLabel(filterField.getLabel());
     filter.getFilterField().addNewFilter(filter);
+    filter.setOperator(GlobalOperatorPolicyService.getInstance().getFirstEnabledOperator(filter.getField(), filter.getOperator()));
     initCustomFieldNumberPattern(filter, field, filter.getFilterField());
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/filter/DashboardFilter.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/filter/DashboardFilter.java
@@ -14,6 +14,7 @@ import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.enums.dashboard.filter.FilterFormat;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.axonivy.portal.enums.dashboard.filter.FilterPeriodType;
+import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterField;
 import com.axonivy.portal.util.filter.field.caze.custom.CaseFilterFieldCustomTimestamp;
 import com.axonivy.portal.util.filter.field.task.TaskFilterFieldExpiryDate;
@@ -215,7 +216,7 @@ public class DashboardFilter implements Serializable {
   }
 
   public void setOperator(FilterOperator operator) {
-    this.operator = operator;
+    this.operator = GlobalOperatorPolicyService.getInstance().getFirstEnabledOperator(this.field, operator);
   }
 
   public FilterPeriodType getPeriodType() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/filter/DashboardFilter.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/dto/dashboard/filter/DashboardFilter.java
@@ -14,7 +14,6 @@ import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.enums.dashboard.filter.FilterFormat;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.axonivy.portal.enums.dashboard.filter.FilterPeriodType;
-import com.axonivy.portal.service.filter.operatorpolicy.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterField;
 import com.axonivy.portal.util.filter.field.caze.custom.CaseFilterFieldCustomTimestamp;
 import com.axonivy.portal.util.filter.field.task.TaskFilterFieldExpiryDate;
@@ -216,7 +215,7 @@ public class DashboardFilter implements Serializable {
   }
 
   public void setOperator(FilterOperator operator) {
-    this.operator = GlobalOperatorPolicyService.getInstance().getFirstEnabledOperator(this.field, operator);
+    this.operator = operator;
   }
 
   public FilterPeriodType getPeriodType() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/enums/dashboard/filter/FilterOperator.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/enums/dashboard/filter/FilterOperator.java
@@ -2,6 +2,7 @@ package com.axonivy.portal.enums.dashboard.filter;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -39,6 +40,14 @@ public enum FilterOperator {
   LESS_OR_EQUAL,
   GREATER,
   GREATER_OR_EQUAL;
+
+  public static Optional<FilterOperator> fromString(String name) {
+    try {
+      return Optional.of(valueOf(name.trim().toUpperCase()));
+    } catch (IllegalArgumentException ex) {
+      return Optional.empty();
+    }
+  }
 
   public String getLabel() {
     return Ivy.cms().co(String.format("/Labels/Enums/FilterOperator/%s", this.name()));

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/BaselineOperatorService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/BaselineOperatorService.java
@@ -1,0 +1,75 @@
+package com.axonivy.portal.service.filter.operatorpolicy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+
+import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
+import ch.ivy.addon.portalkit.enums.DashboardColumnFormat;
+import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
+
+public class BaselineOperatorService {
+
+  private static final Map<String, Set<FilterOperator>> FIELD_OPERATORS_MAP;
+
+  static {
+    Map<String, Set<FilterOperator>> map = new HashMap<>();
+    map.put(DashboardStandardTaskColumn.STATE.getField(), FilterOperator.STATE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.PRIORITY.getField(), FilterOperator.PRIORITY_OPERATORS);
+    map.put(DashboardStandardTaskColumn.RESPONSIBLE.getField(), FilterOperator.RESPONSIBLE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.WORKER.getField(), FilterOperator.WORKER_OPERATORS);
+    map.put(DashboardStandardTaskColumn.CATEGORY.getField(), FilterOperator.CATEGORY_OPERATORS);
+    map.put(DashboardStandardTaskColumn.APPLICATION.getField(), FilterOperator.APPLICATION_OPERATORS);
+    map.put(DashboardStandardTaskColumn.ID.getField(), FilterOperator.ID_OPERATORS);
+    map.put(DashboardStandardTaskColumn.BUSINESS_CASE_ID.getField(), FilterOperator.ID_OPERATORS);
+    map.put(DashboardStandardTaskColumn.TECHNICAL_CASE_ID.getField(), FilterOperator.ID_OPERATORS);
+    map.put(DashboardStandardTaskColumn.CREATED.getField(), FilterOperator.CREATED_DATE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.COMPLETED.getField(), FilterOperator.DATE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.NAME.getField(), FilterOperator.TEXT_OPERATORS);
+    map.put(DashboardStandardTaskColumn.DESCRIPTION.getField(), FilterOperator.TEXT_OPERATORS);
+    map.put(DashboardStandardTaskColumn.EXPIRY.getField(), FilterOperator.DATE_OPERATORS);
+    FIELD_OPERATORS_MAP = Collections.unmodifiableMap(map);
+  }
+
+  public List<FilterOperator> resolveForColumn(ColumnModel column) {
+    if (column == null || !column.canFilter() || StringUtils.isBlank(column.getField())) {
+      return List.of();
+    }
+
+    if (column.getHasCmsValues()) {
+      return List.of(FilterOperator.CONTAINS);
+    }
+
+    List<FilterOperator> byField = resolveByField(column.getField());
+    if (!byField.isEmpty()) {
+      return byField;
+    }
+
+    return resolveByFormat(column.getFormat());
+  }
+
+  public List<FilterOperator> resolveByField(String field) {
+    Set<FilterOperator> operators = FIELD_OPERATORS_MAP.get(field);
+    return operators == null ? List.of() : new ArrayList<>(operators);
+  }
+
+  private List<FilterOperator> resolveByFormat(DashboardColumnFormat format) {
+    if (format == null) {
+      return List.of();
+    }
+
+    return switch (format) {
+      case NUMBER -> new ArrayList<>(FilterOperator.NUMBER_OPERATORS);
+      case TIMESTAMP -> new ArrayList<>(FilterOperator.DATE_OPERATORS);
+      case STRING, TEXT, CUSTOM, CUSTOM_CASE, CUSTOM_BUSINESS_CASE ->
+        new ArrayList<>(FilterOperator.TEXT_OPERATORS);
+    };
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/GlobalOperatorPolicyService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/GlobalOperatorPolicyService.java
@@ -1,0 +1,89 @@
+package com.axonivy.portal.service.filter.operatorpolicy;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.provider.GlobalOperatorPolicyProvider;
+import com.axonivy.portal.util.filter.field.FilterField;
+
+import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
+
+public class GlobalOperatorPolicyService {
+
+  private static GlobalOperatorPolicyService instance;
+
+  public static GlobalOperatorPolicyService getInstance() {
+    if (instance == null) {
+      instance = new GlobalOperatorPolicyService();
+    }
+    return instance;
+  }
+
+  private final GlobalOperatorPolicyProvider globalPolicyProvider;
+  private final BaselineOperatorService baselineOperatorService;
+
+  public GlobalOperatorPolicyService() {
+    this.globalPolicyProvider = new GlobalOperatorPolicyProvider();
+    this.baselineOperatorService = new BaselineOperatorService();
+  }
+
+  public boolean isOperatorGloballyEnabled(FilterOperator operator) {
+    return operator != null && !globalPolicyProvider.getPolicy().isDisabled(operator);
+  }
+
+  public boolean isFilterAllowedByGlobalPolicy(DashboardFilter filter) {
+    return filter != null && isOperatorGloballyEnabled(filter.getOperator());
+  }
+
+  public FilterOperator getFirstEnabledOperator(String field, FilterOperator defaultOp) {
+    var policy = globalPolicyProvider.getPolicy();
+    if (!policy.isDisabled(defaultOp)) {
+      return defaultOp;
+    }
+    List<FilterOperator> operators = baselineOperatorService.resolveByField(field);
+    return operators.stream()
+        .filter(op -> op != null && !policy.isDisabled(op))
+        .findFirst()
+        .orElse(null);
+  }
+
+  public List<FilterOperator> keepGloballyEnabledOperators(List<FilterOperator> operators) {
+    if (CollectionUtils.isEmpty(operators)) {
+      return List.of();
+    }
+    var policy = globalPolicyProvider.getPolicy();
+    return operators.stream()
+        .filter(op -> op != null && !policy.isDisabled(op))
+        .collect(Collectors.toList());
+  }
+
+  public List<DashboardFilter> keepGloballyEnabledFilters(List<DashboardFilter> filters) {
+    if (CollectionUtils.isEmpty(filters)) {
+      return List.of();
+    }
+    var policy = globalPolicyProvider.getPolicy();
+    return filters.stream()
+        .filter(f -> f != null && f.getOperator() != null && !policy.isDisabled(f.getOperator()))
+        .collect(Collectors.toList());
+  }
+
+  public boolean hasAnyGloballyEnabledOperator(FilterField field) {
+    return hasAnyGloballyEnabledOperator(baselineOperatorService.resolveByField(field.getName()));
+  }
+
+  public boolean hasAnyGloballyEnabledOperator(ColumnModel column) {
+    return hasAnyGloballyEnabledOperator(baselineOperatorService.resolveForColumn(column));
+  }
+
+  private boolean hasAnyGloballyEnabledOperator(List<FilterOperator> operators) {
+    if (CollectionUtils.isEmpty(operators)) {
+        return false;
+    }
+    var policy = globalPolicyProvider.getPolicy();
+    return operators.stream().anyMatch(operator -> operator != null && !policy.isDisabled(operator));
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/model/GlobalOperatorPolicy.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/model/GlobalOperatorPolicy.java
@@ -1,0 +1,35 @@
+package com.axonivy.portal.service.filter.operatorpolicy.model;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+
+public class GlobalOperatorPolicy implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Set<FilterOperator> disabledOperators;
+
+  private GlobalOperatorPolicy(Set<FilterOperator> disabledOperators) {
+    this.disabledOperators = disabledOperators;
+  }
+
+  public static GlobalOperatorPolicy empty() {
+    return new GlobalOperatorPolicy(Collections.emptySet());
+  }
+
+  public static GlobalOperatorPolicy of(Collection<FilterOperator> disabledOperators) {
+    return new GlobalOperatorPolicy(Set.copyOf(disabledOperators));
+  }
+
+  public boolean isDisabled(FilterOperator operator) {
+    return disabledOperators.contains(operator);
+  }
+
+  public Set<FilterOperator> getDisabledOperators() {
+    return disabledOperators;
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/provider/GlobalOperatorPolicyProvider.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/provider/GlobalOperatorPolicyProvider.java
@@ -1,0 +1,42 @@
+package com.axonivy.portal.service.filter.operatorpolicy.provider;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.model.GlobalOperatorPolicy;
+
+import ch.ivy.addon.portalkit.enums.GlobalVariable;
+import ch.ivyteam.ivy.environment.Ivy;
+
+public class GlobalOperatorPolicyProvider {
+
+  private static final String GLOBAL_OPERATOR_POLICY_KEY = GlobalVariable.FILTER_OPERATOR_POLICY.getKey();
+
+  public GlobalOperatorPolicy getPolicy() {
+    return parse(Ivy.var().get(GLOBAL_OPERATOR_POLICY_KEY));
+  }
+
+  GlobalOperatorPolicy parse(String rawPolicy) {
+    if (StringUtils.isBlank(rawPolicy)) {
+      return GlobalOperatorPolicy.of(List.of(FilterOperator.values()));
+    }
+
+    Set<FilterOperator> enabledOperators = parseOperators(rawPolicy.trim().split(","));
+    List<FilterOperator> disabledOperators = Set.of(FilterOperator.values()).stream()
+        .filter(operator -> !enabledOperators.contains(operator)).collect(Collectors.toList());
+
+    return disabledOperators.isEmpty() ? GlobalOperatorPolicy.empty() : GlobalOperatorPolicy.of(disabledOperators);
+  }
+
+  private Set<FilterOperator> parseOperators(String[] operators) {
+    return Arrays.stream(operators).filter(StringUtils::isNotBlank)
+        .map(FilterOperator::fromString).filter(Optional::isPresent).map(Optional::get)
+        .collect(Collectors.toSet());
+  }
+}

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
@@ -132,11 +132,15 @@
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/defaultValue')}"
             filterBy="#{setting.defaultValue}" filterMatchMode="contains" styleClass="settings-table-default-value-column">
-            <h:outputText value="#{setting.defaultValue}" />
+            <h:panelGroup layout="block" styleClass="block w-full u-truncate-text">
+              <h:outputText value="#{setting.defaultValue}" />
+            </h:panelGroup>
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/currentValue')}"
             filterBy="#{setting.displayValue}" filterMatchMode="contains" styleClass="settings-table-current-value-column">
-            <h:outputText value="#{setting.displayValue}" />
+            <h:panelGroup layout="block" styleClass="block w-full u-truncate-text">
+              <h:outputText value="#{setting.displayValue}" />
+            </h:panelGroup>
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/note')}"
             filterBy="#{setting.note}" filterMatchMode="contains">
@@ -361,21 +365,23 @@
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'SELECTION'}">
-              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="value-setting-dropdown">
+              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="w-full">
                 <f:selectItems value="#{data.dropDownValues}" var="value" itemLabel="#{adminSettingBean.getDropdownItemlabel(value)}" />
               </p:selectOneMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'EXTERNAL_SELECTION'}">
-              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="value-setting-dropdown">
+              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="w-full">
                 <f:selectItems value="#{data.externalDropDownValues.entrySet()}" var="entry" itemValue="#{entry.key}" itemLabel="#{data.selectedSetting.key eq 'Portal.Homepage' ? entry.value : entry.value.getLabel()}" />
               </p:selectOneMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'MULTI_EXTERNAL_SELECTIONS'}">
-              <p:selectManyCheckbox value="#{data.selectedMultiSettings}" id="valueSetting">
+              <p:selectCheckboxMenu id="valueSetting" value="#{data.selectedMultiSettings}"
+                updateLabel="true" filter="true" panelStyleClass="value-setting-dropdown-panel"
+                styleClass="w-full" scrollHeight="250">
                 <f:selectItems value="#{data.externalDropDownValues.entrySet()}" var="entry" itemValue="#{entry.key}" itemLabel="#{entry.value.getLabel()}" />
-              </p:selectManyCheckbox>
+              </p:selectCheckboxMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'PASSWORD'}">

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/TableWidget.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/TableWidget.xhtml
@@ -254,7 +254,13 @@
   
             <h:panelGroup id="widget-filter-content" styleClass="ui-g-9 u-padding-0 ui-sm-12 flex flex-column" layout="block">
               <div class="ui-g-12 filter-overlay-panel__header pt-3 flex ">
-                <strong class="ui-g-12">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterOptionHeader')}</strong>
+                <div class="ui-g-12 flex align-items-center gap-1">
+                  <strong>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterOptionHeader')}</strong>
+                  <h:outputText id="filter-option-header-info-#{index}" styleClass="si si-information-circle" />
+                  <p:tooltip for="filter-option-header-info-#{index}"
+                      value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterOptionHeaderTooltip')}"
+                      position="bottom" />
+                </div>
                 <p:commandButton icon="si si-remove" id="widget-filter-cancel-button"
                     ariaLabel="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/closeContext', [ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterPanelHeader')])}"
                     styleClass="ui-overlaypanel-footer__cancel flex align-items-center ui-button-flat rounded-button text-2xl"

--- a/AxonIvyPortal/portal/webContent/resources/css/module.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/module.css
@@ -2878,6 +2878,13 @@ _:-ms-fullscreen, :root .circle-process-chain .circle-vertical-process-step:not(
   word-break: break-all;
 }
 
+.admin-settings-container .ui-selectcheckboxmenu .ui-selectcheckboxmenu-label {
+  max-width: calc(100% - 2rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .announcement-information {
   max-width: calc(100% - 200px);
   float: left;


### PR DESCRIPTION
- Admins can now configure which filter operators are globally enabled via a new `Portal.ComplexFilter.Operators` multi-select in Admin Settings.
- Disabled operators are silently pruned from runtime filter dropdowns, apply/save flows, and session restore.
- New 4 classes: `GlobalOperatorPolicy, GlobalOperatorPolicyProvider, GlobalOperatorPolicyService, BaselineOperatorService` wrap new logic to manage operators.
- Add new test file `DashboardFilterOperatorPolicyTest`.