### PR TITLE
IVYPORTAL-20522 Add operator policy module and global operator admin setting

### DIFF
--- a/AxonIvyPortal/portal/cms/cms.yaml
+++ b/AxonIvyPortal/portal/cms/cms.yaml
@@ -163,6 +163,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Set URL to download Axon Ivy mobile app on Apple Store.
       BaseQRCodeUrl: Set Base URL for QR code to display.
       GooglePlayURL: Set URL to download Axon Ivy mobile app on Google Play.
+      DashboardFilterOperatorPolicy: Unchecked operators are disabled globally.
       behaviourWhenClickingOnLineInCaseList: Toggle between accessing case details or business details when clicking on a case in the case widget on the dashboard, global search, related cases, and process widget in combined mode.
       behaviourWhenClickingOnLineInTaskList: For switch behaviours (run the task or access task details) when clicking on a line in task list, task widget of dashboard and related tasks  in case details page.
       chatMaxConnection: 'The set number controls the amount of tabs allowed with active chat. If more tabs are opened, the chat will be disabled in inactive tabs. Allowed values between 1-5 '
@@ -590,6 +591,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     EmptyFilterMessage: No widget filter found
     Filter:
       FilterOptionHeader: Filter options
+      FilterOptionHeaderTooltip: Some filter fields and operators may be disabled by your administrator. Filters using disabled fields or operators will be automatically removed. Please contact your administrator for more information.
       FilterPanelHeader: Filter panel
       ManageWidgetFilterHeader: Widget filter management
       NotFound: No filter found
@@ -668,6 +670,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
+    operators: Operators
+    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms_de.yaml
+++ b/AxonIvyPortal/portal/cms/cms_de.yaml
@@ -220,6 +220,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Legen Sie die URL für den Download der Axon Ivy Mobile App im Apple Store fest.
       ApplicationName: Der Name der Anwendung, der auf dem Seitentitel angezeigt werden soll.
       BaseQRCodeUrl: Legen Sie die Basis-URL für den anzuzeigenden QR-Code fest.
+      DashboardFilterOperatorPolicy: Nicht ausgewählte Operatoren werden global deaktiviert.
       DefaultThemeMode: Der Standardthemenmodus der Anwendung
       EnableSwitchThemeModeButton: Setzen Sie diesen Wert auf true, um die Schaltfläche "Thema wechseln" zu aktivieren.
       GlobalSearchScopeCategoriesNote: Festlegung der Typen, nach denen bei der globalen Suche gesucht werden soll
@@ -830,6 +831,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Dieses Widget kann eine externe Webseite anzeigen.
     Filter:
       FilterOptionHeader: Filter-Optionen
+      FilterOptionHeaderTooltip: Einige Filterfelder und Operatoren wurden möglicherweise von Ihrem Administrator deaktiviert. Filter, die deaktivierte Felder oder Operatoren verwenden, werden automatisch entfernt. Bitte wenden Sie sich an Ihren Administrator für weitere Informationen.
       FilterPanelHeader: Filterbereich
       ManageWidgetFilterHeader: Widget-Filter-Verwaltung
       NotFound: Kein Filter gefunden
@@ -974,6 +976,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Sie haben keine Berechtigung, Dashboards zu sehen.
     noWidget: Es sind aktuell keine Widgets auf diesem Dashboard vorhanden
     numberPattern: Zahlen-Muster
+    operators: Operatoren
+    operatorPolicyTooltip: Wenn Operatoren vom Administrator global deaktiviert sind, können sie hier nicht aktiviert werden. Der Filter eines Felds kann nicht aktiviert werden, wenn alle Operatoren global deaktiviert sind.
     preview: Vorschau
     processList: Prozessliste
     processListIntroduction: Dieses Widget zeigt verfügbare Prozessstarts an. Sie haben die Möglichkeit, unterschiedliche Formate zu wählen

--- a/AxonIvyPortal/portal/cms/cms_en.yaml
+++ b/AxonIvyPortal/portal/cms/cms_en.yaml
@@ -221,6 +221,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Set URL to download Axon Ivy mobile app on Apple Store.
       ApplicationName: The application name that will be displayed on the page title.
       BaseQRCodeUrl: Set Base URL for QR code to display.
+      DashboardFilterOperatorPolicy: Unchecked operators are disabled globally.
       DefaultThemeMode: The default theme mode of the application
       EnableSwitchThemeModeButton: Set to true to enable the switch theme button.
       GlobalSearchScopeCategoriesNote: Defining the types that the global search will search for
@@ -826,6 +827,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: This widget can display an external webpage.
     Filter:
       FilterOptionHeader: Filter options
+      FilterOptionHeaderTooltip: Some filter fields and operators may be disabled by your administrator. Filters using disabled fields or operators will be automatically removed. Please contact your administrator for more information.
       FilterPanelHeader: Filter panel
       ManageWidgetFilterHeader: Widget filter management
       NotFound: No filter found
@@ -970,6 +972,9 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
+    operators: Operators
+    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
+    operatorPolicyInvalid: 'Some selected operators are disabled by global configuration. Please review: {0}'
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms_es.yaml
+++ b/AxonIvyPortal/portal/cms/cms_es.yaml
@@ -220,6 +220,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Establezca la URL para descargar la aplicación móvil Axon Ivy en Apple Store.
       ApplicationName: El nombre de la aplicación que se mostrará en el título de la página.
       BaseQRCodeUrl: Establezca la URL base para mostrar el código QR.
+      DashboardFilterOperatorPolicy: Los operadores no marcados se deshabilitan globalmente.
       DefaultThemeMode: El modo de tema por defecto de la aplicación
       EnableSwitchThemeModeButton: Establecer en true para habilitar el botón de cambio de tema.
       GlobalSearchScopeCategoriesNote: Definición de los tipos que buscará la búsqueda global
@@ -828,6 +829,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Este widget puede mostrar una página web externa.
     Filter:
       FilterOptionHeader: Opciones de filtro
+      FilterOptionHeaderTooltip: Algunos campos de filtro y operadores pueden estar deshabilitados por su administrador. Los filtros que utilicen campos u operadores deshabilitados se eliminarán automáticamente. Comuníquese con su administrador para obtener más información.
       FilterPanelHeader: Panel de filtro
       ManageWidgetFilterHeader: Gestión de filtros de widgets
       NotFound: No se ha encontrado ningún filtro
@@ -972,6 +974,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: No tienes permisos para ver los dashboards.
     noWidget: No hay widgets para este tablero
     numberPattern: Patrón de números
+    operators: Operadores
+    operatorPolicyTooltip: Si los operadores están deshabilitados globalmente por el administrador, no pueden habilitarse aquí. El filtro de un campo no puede habilitarse cuando todos los operadores están deshabilitados globalmente.
     preview: Vista previa
     processList: Lista de procesos
     processListIntroduction: Este widget muestra los inicios de procesos disponibles. Tiene la posibilidad de elegir diferentes formatos

--- a/AxonIvyPortal/portal/cms/cms_fr.yaml
+++ b/AxonIvyPortal/portal/cms/cms_fr.yaml
@@ -220,6 +220,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Définir l'URL pour télécharger l'application mobile Axon Ivy sur l'Apple Store.
       ApplicationName: Le nom de l'application qui sera affiché dans le titre de la page.
       BaseQRCodeUrl: Définir l'URL de base du code QR à afficher.
+      DashboardFilterOperatorPolicy: Les opérateurs décochés sont désactivés globalement.
       DefaultThemeMode: Le mode de thème par défaut de l'application
       EnableSwitchThemeModeButton: Défini à true pour activer le bouton de changement de thème.
       GlobalSearchScopeCategoriesNote: Définition des types recherchés par la recherche globale
@@ -828,6 +829,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Ce widget peut afficher une page web externe.
     Filter:
       FilterOptionHeader: Options de filtre
+      FilterOptionHeaderTooltip: Certains champs de filtre et opérateurs peuvent être désactivés par votre administrateur. Les filtres utilisant des champs ou des opérateurs désactivés seront automatiquement supprimés. Veuillez contacter votre administrateur pour plus d'informations.
       FilterPanelHeader: Panneau de filtre
       ManageWidgetFilterHeader: Gestion des filtres des widgets
       NotFound: Aucun filtre trouvé
@@ -972,6 +974,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Vous n'avez pas les permissions pour voir les tableaux de bord.
     noWidget: Il n'y a pas de widgets fournis pour ce tableau de bord.
     numberPattern: Modèle de numéro
+    operators: Opérateurs
+    operatorPolicyTooltip: Si les opérateurs sont désactivés globalement par l'administrateur, ils ne peuvent pas être activés ici. Le filtre d'un champ ne peut pas être activé lorsque tous les opérateurs sont désactivés globalement.
     preview: Aperçu
     processList: Liste des processus
     processListIntroduction: Ce widget montre les démarrages de processus disponibles. Vous avez la possibilité de choisir différents formats

--- a/AxonIvyPortal/portal/cms/cms_ja.yaml
+++ b/AxonIvyPortal/portal/cms/cms_ja.yaml
@@ -221,6 +221,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Apple Store で Axon Ivy モバイル アプリをダウンロードするための URL を設定します。
       ApplicationName: ページタイトルに表示されるアプリケーション名。
       BaseQRCodeUrl: 表示するQRコードのベースURLを設定します。
+      DashboardFilterOperatorPolicy: 未選択の演算子はグローバルで無効になります。
       DefaultThemeMode: アプリケーションのテーマモードの初期値
       EnableDocumentPreview: ドキュメントのプレビューを有効にするには true に設定してください。（プレビュー可能なファイルの種類：pdf、png、txt、log）
       EnableSwitchThemeModeButton: テーマ切り替えボタンを有効にするには true に設定してください。
@@ -827,6 +828,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: このウィジェットは外部Webページを表示できます。
     Filter:
       FilterOptionHeader: フィルターオプション
+      FilterOptionHeaderTooltip: 一部のフィルターフィールドや演算子は管理者によって無効化されている場合があります。無効なフィールドまたは演算子を使用しているフィルターは自動的に削除されます。詳細については管理者にお問い合わせください。
       FilterPanelHeader: フィルターパネル
       ManageWidgetFilterHeader: ウィジェットフィルター管理
       NotFound: フィルターが見つかりません
@@ -971,6 +973,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: ダッシュボードを表示する権限がありません。
     noWidget: このダッシュボードにはウィジェットが用意されていません
     numberPattern: 番号パターン
+    operators: オペレーター
+    operatorPolicyTooltip: オペレーターが管理者によってグローバルに無効化されている場合、ここで有効化することはできません。すべてのオペレーターがグローバルに無効化されている場合、フィールドのフィルターを有効化することはできません。
     preview: プレビュー
     processList: プロセスリスト
     processListIntroduction: このウィジェットには、利用可能なプロセス開始が表示されます。さまざまな形式を選択できます。

--- a/AxonIvyPortal/portal/config/variables.yaml
+++ b/AxonIvyPortal/portal/config/variables.yaml
@@ -62,6 +62,9 @@ Variables:
       # You can customize the name and icon of the main menu entry for Portal dashboards via this JSON file.
       # [file: json]
       MainMenuEntry: ""
+    # Configure enabled operators for complex filters as comma-separated enum names.
+    ComplexFilter:
+      Operators: TODAY,YESTERDAY,IS,IS_NOT,BEFORE,AFTER,BETWEEN,NOT_BETWEEN,CURRENT,LAST,NEXT,EMPTY,NOT_EMPTY,CONTAINS,NOT_CONTAINS,IN,NOT_IN,START_WITH,NOT_START_WITH,END_WITH,NOT_END_WITH,CURRENT_USER_CAN_WORK_ON,CURRENT_USER,NO_CATEGORY,EQUAL,NOT_EQUAL,LESS,LESS_OR_EQUAL,GREATER,GREATER_OR_EQUAL
     Processes:
       # The standard setting of view mode in the process list.
       # [enum: COMPACT, IMAGE, GRID]

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/GlobalSetting.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/GlobalSetting.java
@@ -13,6 +13,7 @@ import com.axonivy.portal.enums.SearchScopeCaseField;
 import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.enums.SidebarMode;
 import com.axonivy.portal.enums.ThemeMode;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -126,6 +127,7 @@ public class GlobalSetting extends AbstractConfiguration {
       case GlobalSearchScopeCategory castObject -> castObject.getLabel();
       case DelegationAppendOption castObject -> castObject.getLabel();
       case SidebarMode castObject -> castObject.getLabel();
+      case FilterOperator castObject -> castObject.getLabel();
       default -> (String) object;
     };
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/AbstractColumn.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/dto/dashboard/AbstractColumn.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -58,6 +59,8 @@ public abstract class AbstractColumn implements Serializable {
   protected String fieldStyle;
   protected Boolean visible;
   protected Boolean enableFilter;
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  protected List<FilterOperator> allowedOperators;
   protected Boolean quickSearch;
   protected Boolean sortable;
   protected DashboardColumnFormat format;
@@ -260,6 +263,14 @@ public abstract class AbstractColumn implements Serializable {
 
   public void setEnableFilter(Boolean enableFilter) {
     this.enableFilter = enableFilter;
+  }
+
+  public List<FilterOperator> getAllowedOperators() {
+    return allowedOperators;
+  }
+
+  public void setAllowedOperators(List<FilterOperator> allowedOperators) {
+    this.allowedOperators = allowedOperators;
   }
 
   public Boolean getSortable() {
@@ -497,7 +508,7 @@ public abstract class AbstractColumn implements Serializable {
   
   @JsonIgnore
   public boolean getHasCmsValues() {
-    return hasCmsValues;
+    return Boolean.TRUE.equals(hasCmsValues);
   }
   
   public void setHasCmsValues(Boolean hasCmsValues) {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/enums/GlobalVariable.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/enums/GlobalVariable.java
@@ -16,6 +16,7 @@ import com.axonivy.portal.enums.SearchScopeCaseField;
 import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.enums.SidebarMode;
 import com.axonivy.portal.enums.ThemeMode;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 
 import ch.addon.portal.generic.userprofile.homepage.HomepageType;
 import ch.ivy.addon.portalkit.document.DocumentExtensionConstants;
@@ -95,7 +96,9 @@ public enum GlobalVariable {
       "enablePinCase"),ALLOW_KEYBOARD_SHORTCUTS_CONFIGURATION(
           "Portal.Accessibility.AllowKeyboardShortcutsConfiguration", GlobalVariableType.SELECTION, Option.TRUE.toString(), "allowKeyboardShortcutsConfiguration"),
   SIDEBAR_MODE("Portal.Sidebar.Mode", GlobalVariableType.EXTERNAL_SELECTION, SidebarMode.HOVER.name(), "sidebarMode", getSidebarModes()),
-  MAXIMUM_SELECTED_TASKS("Portal.Tasks.MaximumSelectedTasks", GlobalVariableType.NUMBER, "20", "maximumSelectedTasks");
+  MAXIMUM_SELECTED_TASKS("Portal.Tasks.MaximumSelectedTasks", GlobalVariableType.NUMBER, "20", "maximumSelectedTasks"),
+  FILTER_OPERATOR_POLICY("Portal.ComplexFilter.Operators", GlobalVariableType.MULTI_EXTERNAL_SELECTIONS,
+      getFilterOperatorOptions(), "DashboardFilterOperatorPolicy", getFilterOperatorOptions());
 
   private String key;
   private GlobalVariableType type;
@@ -302,6 +305,14 @@ public enum GlobalVariable {
     Map<String, Object> result = new HashMap<>();
     for (SidebarMode mode : SidebarMode.values()) {
       result.put(mode.name(), mode);
+    }
+    return result;
+  }
+
+  private static Map<String, Object> getFilterOperatorOptions() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    for (FilterOperator operator : FilterOperator.values()) {
+      result.put(operator.name(), operator);
     }
     return result;
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/enums/dashboard/filter/FilterOperator.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/enums/dashboard/filter/FilterOperator.java
@@ -2,6 +2,7 @@ package com.axonivy.portal.enums.dashboard.filter;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -39,6 +40,14 @@ public enum FilterOperator {
   LESS_OR_EQUAL,
   GREATER,
   GREATER_OR_EQUAL;
+
+  public static Optional<FilterOperator> fromString(String name) {
+    try {
+      return Optional.of(valueOf(name.trim().toUpperCase()));
+    } catch (IllegalArgumentException ex) {
+      return Optional.empty();
+    }
+  }
 
   public String getLabel() {
     return Ivy.cms().co(String.format("/Labels/Enums/FilterOperator/%s", this.name()));

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/model/GlobalOperatorPolicy.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/model/GlobalOperatorPolicy.java
@@ -1,0 +1,35 @@
+package com.axonivy.portal.service.filter.operatorpolicy.model;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+
+public class GlobalOperatorPolicy implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Set<FilterOperator> disabledOps;
+
+  private GlobalOperatorPolicy(Set<FilterOperator> disabledOps) {
+    this.disabledOps = disabledOps;
+  }
+
+  public static GlobalOperatorPolicy empty() {
+    return new GlobalOperatorPolicy(Collections.emptySet());
+  }
+
+  public static GlobalOperatorPolicy of(Collection<FilterOperator> disabledOps) {
+    return new GlobalOperatorPolicy(Set.copyOf(disabledOps));
+  }
+
+  public boolean isDisabled(FilterOperator op) {
+    return disabledOps.contains(op);
+  }
+
+  public Set<FilterOperator> getDisabledOperators() {
+    return disabledOps;
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/model/OperatorPolicy.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/model/OperatorPolicy.java
@@ -1,0 +1,43 @@
+package com.axonivy.portal.service.filter.operatorpolicy.model;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+
+public class OperatorPolicy implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Map<String, Set<FilterOperator>> allowedOperatorsByField;
+
+  private OperatorPolicy(Map<String, Set<FilterOperator>> allowedOperatorsByField) {
+    this.allowedOperatorsByField = allowedOperatorsByField;
+  }
+
+  public static OperatorPolicy empty() {
+    return new OperatorPolicy(Collections.emptyMap());
+  }
+
+  public static OperatorPolicy of(Map<String, ? extends Collection<FilterOperator>> allowedOperatorsByField) {
+    Map<String, Set<FilterOperator>> immutableMap = allowedOperatorsByField.entrySet().stream()
+        .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> Set.copyOf(entry.getValue())));
+    return new OperatorPolicy(immutableMap);
+  }
+
+  public boolean hasPolicyForField(String field) {
+    return allowedOperatorsByField.containsKey(field);
+  }
+
+  public Set<FilterOperator> getAllowedOperators(String field) {
+    return allowedOperatorsByField.getOrDefault(field, Collections.emptySet());
+  }
+
+  public Map<String, Set<FilterOperator>> getAllowedOperatorsByField() {
+    return allowedOperatorsByField;
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/provider/GlobalOperatorPolicyProvider.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/provider/GlobalOperatorPolicyProvider.java
@@ -1,0 +1,45 @@
+package com.axonivy.portal.service.filter.operatorpolicy.provider;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.model.GlobalOperatorPolicy;
+
+import ch.ivy.addon.portalkit.enums.GlobalVariable;
+import ch.ivyteam.ivy.environment.Ivy;
+
+public class GlobalOperatorPolicyProvider implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final String GLOBAL_OPERATOR_POLICY_KEY = GlobalVariable.FILTER_OPERATOR_POLICY.getKey();
+
+  public GlobalOperatorPolicy getPolicy() {
+    return parse(Ivy.var().get(GLOBAL_OPERATOR_POLICY_KEY));
+  }
+
+  GlobalOperatorPolicy parse(String rawPolicy) {
+    if (StringUtils.isBlank(rawPolicy)) {
+      return GlobalOperatorPolicy.of(Set.of(FilterOperator.values()));
+    }
+
+    Set<FilterOperator> enabledOps = parseOperators(rawPolicy.trim().split(","));
+    List<FilterOperator> disabledOps = Set.of(FilterOperator.values()).stream()
+        .filter(op -> !enabledOps.contains(op)).collect(Collectors.toList());
+
+    return disabledOps.isEmpty() ? GlobalOperatorPolicy.empty() : GlobalOperatorPolicy.of(disabledOps);
+  }
+
+  private Set<FilterOperator> parseOperators(String[] ops) {
+    return Arrays.stream(ops).filter(StringUtils::isNotBlank)
+        .map(FilterOperator::fromString).filter(Optional::isPresent).map(Optional::get)
+        .collect(Collectors.toSet());
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/provider/WidgetOperatorPolicyProvider.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/provider/WidgetOperatorPolicyProvider.java
@@ -1,0 +1,30 @@
+package com.axonivy.portal.service.filter.operatorpolicy.provider;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.model.OperatorPolicy;
+
+import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
+
+public class WidgetOperatorPolicyProvider implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  public OperatorPolicy getPolicy(List<ColumnModel> columns) {
+    if (CollectionUtils.isEmpty(columns)) {
+      return OperatorPolicy.empty();
+    }
+
+    Map<String, List<FilterOperator>> policyByField = new LinkedHashMap<>();
+    columns.stream().filter(column -> column.getAllowedOperators() != null)
+        .forEach(column -> policyByField.put(column.getField(), column.getAllowedOperators()));
+
+    return policyByField.isEmpty() ? OperatorPolicy.empty() : OperatorPolicy.of(policyByField);
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/service/BaselineOperatorService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/service/BaselineOperatorService.java
@@ -1,0 +1,98 @@
+package com.axonivy.portal.service.filter.operatorpolicy.service;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+
+import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
+import ch.ivy.addon.portalkit.enums.DashboardColumnFormat;
+import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
+import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
+
+public class BaselineOperatorService implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final Map<String, Set<FilterOperator>> FIELD_OPERATORS_MAP;
+
+  static {
+    Map<String, Set<FilterOperator>> map = new HashMap<>();
+    map.put(DashboardStandardTaskColumn.STATE.getField(), FilterOperator.STATE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.PRIORITY.getField(), FilterOperator.PRIORITY_OPERATORS);
+    map.put(DashboardStandardTaskColumn.RESPONSIBLE.getField(), FilterOperator.RESPONSIBLE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.WORKER.getField(), FilterOperator.WORKER_OPERATORS);
+    map.put(DashboardStandardCaseColumn.CREATOR.getField(), FilterOperator.CREATOR_OPERATORS);
+    map.put(DashboardStandardTaskColumn.CATEGORY.getField(), FilterOperator.CATEGORY_OPERATORS);
+    map.put(DashboardStandardTaskColumn.APPLICATION.getField(), FilterOperator.APPLICATION_OPERATORS);
+    map.put(DashboardStandardTaskColumn.ID.getField(), FilterOperator.ID_OPERATORS);
+    map.put(DashboardStandardTaskColumn.BUSINESS_CASE_ID.getField(), FilterOperator.ID_OPERATORS);
+    map.put(DashboardStandardTaskColumn.TECHNICAL_CASE_ID.getField(), FilterOperator.ID_OPERATORS);
+    map.put(DashboardStandardTaskColumn.CREATED.getField(), FilterOperator.CREATED_DATE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.COMPLETED.getField(), FilterOperator.DATE_OPERATORS);
+    map.put(DashboardStandardTaskColumn.NAME.getField(), FilterOperator.TEXT_OPERATORS);
+    map.put(DashboardStandardTaskColumn.DESCRIPTION.getField(), FilterOperator.TEXT_OPERATORS);
+    map.put(DashboardStandardTaskColumn.EXPIRY.getField(), FilterOperator.DATE_OPERATORS);
+    FIELD_OPERATORS_MAP = Collections.unmodifiableMap(map);
+  }
+
+  public List<FilterOperator> resolveForColumn(ColumnModel column) {
+    if (!column.canFilter()) {
+      return List.of();
+    }
+
+    if (Boolean.TRUE.equals(column.getHasCmsValues())) {
+      return List.of(FilterOperator.CONTAINS);
+    }
+
+    List<FilterOperator> byField = resolveByField(column.getField());
+    if (!byField.isEmpty()) {
+      return byField;
+    }
+
+    return resolveByFormat(column.getFormat());
+  }
+
+  public List<FilterOperator> resolveForFilter(DashboardFilter filter) {
+    if (filter.isCustomDateField() || filter.isExpiryDateField()) {
+      return new ArrayList<>(FilterOperator.DATE_OPERATORS);
+    }
+
+    List<FilterOperator> byField = resolveByField(filter.getField());
+    if (!byField.isEmpty()) {
+      return byField;
+    }
+
+    if (filter.isNumberField()) {
+      return new ArrayList<>(FilterOperator.NUMBER_OPERATORS);
+    }
+
+    if (filter.isTextField()) {
+      return new ArrayList<>(FilterOperator.TEXT_OPERATORS);
+    }
+
+    return Collections.emptyList();
+  }
+
+  public List<FilterOperator> resolveByField(String field) {
+    Set<FilterOperator> operators = FIELD_OPERATORS_MAP.get(field);
+    return operators != null ? new ArrayList<>(operators) : Collections.emptyList();
+  }
+
+  private List<FilterOperator> resolveByFormat(DashboardColumnFormat format) {
+    if (format == null) {
+      return Collections.emptyList();
+    }
+    return switch (format) {
+      case NUMBER -> new ArrayList<>(FilterOperator.NUMBER_OPERATORS);
+      case TIMESTAMP -> new ArrayList<>(FilterOperator.DATE_OPERATORS);
+      case STRING, TEXT, CUSTOM, CUSTOM_CASE, CUSTOM_BUSINESS_CASE -> new ArrayList<>(FilterOperator.TEXT_OPERATORS);
+    };
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/service/GlobalOperatorPolicyService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/service/GlobalOperatorPolicyService.java
@@ -1,0 +1,59 @@
+package com.axonivy.portal.service.filter.operatorpolicy.service;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.model.GlobalOperatorPolicy;
+import com.axonivy.portal.service.filter.operatorpolicy.provider.GlobalOperatorPolicyProvider;
+
+import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
+
+public class GlobalOperatorPolicyService implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  protected final GlobalOperatorPolicy globalPolicy;
+  protected final BaselineOperatorService baseOpService;
+
+  public GlobalOperatorPolicyService() {
+    this.globalPolicy = new GlobalOperatorPolicyProvider().getPolicy();
+    this.baseOpService = new BaselineOperatorService();
+  }
+
+  public BaselineOperatorService getBaselineOperatorService() {
+    return this.baseOpService;
+  }
+
+  public boolean isOperatorGloballyEnabled(FilterOperator op) {
+    return !globalPolicy.isDisabled(op);
+  }
+
+  public boolean isFilterAllowedByGlobalPolicy(DashboardFilter filter) {
+    return !globalPolicy.isDisabled(filter.getOperator());
+  }
+
+  public List<FilterOperator> keepGloballyEnabledOperators(List<FilterOperator> ops) {
+    return ops.stream()
+        .filter(op -> !globalPolicy.isDisabled(op))
+        .collect(Collectors.toList());
+  }
+
+  public List<ColumnModel> getColumnsWithGloballyEnabledOperators(List<ColumnModel> columns) {
+    return columns.stream()
+        .filter(col -> !keepGloballyEnabledOperators(baseOpService.resolveForColumn(col)).isEmpty())
+        .collect(Collectors.toList());
+  }
+
+  public List<FilterOperator> resolveEffectiveOperators(DashboardFilter filter) {
+    return keepGloballyEnabledOperators(baseOpService.resolveForFilter(filter));
+  }
+
+  public Optional<FilterOperator> findFirstEnabledOp(DashboardFilter filter, FilterOperator defaultOp) {
+    List<FilterOperator> effective = resolveEffectiveOperators(filter);
+    return effective.contains(defaultOp) ? Optional.of(defaultOp) : effective.stream().findFirst();
+  }
+}

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/service/OperatorPolicyService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/service/OperatorPolicyService.java
@@ -1,0 +1,66 @@
+package com.axonivy.portal.service.filter.operatorpolicy.service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.model.OperatorPolicy;
+import com.axonivy.portal.service.filter.operatorpolicy.provider.WidgetOperatorPolicyProvider;
+
+import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
+
+public class OperatorPolicyService extends GlobalOperatorPolicyService {
+
+  private static final long serialVersionUID = 1L;
+
+  private final OperatorPolicy widgetPolicy;
+
+  public OperatorPolicyService(List<ColumnModel> columnModels) {
+    super();
+    this.widgetPolicy = new WidgetOperatorPolicyProvider().getPolicy(columnModels);
+  }
+
+  public OperatorPolicy readWidgetPolicy() {
+    return this.widgetPolicy;
+  }
+
+  private boolean hasNoWidgetPolicyForField(String field) {
+    return !widgetPolicy.hasPolicyForField(field);
+  }
+
+  private boolean isFilterAllowedByPolicy(DashboardFilter filter) {
+    if (!this.isFilterAllowedByGlobalPolicy(filter)) {
+      return false;
+    }
+
+    if (this.hasNoWidgetPolicyForField(filter.getField())) {
+      return true;
+    }
+
+    return widgetPolicy.getAllowedOperators(filter.getField()).contains(filter.getOperator());
+  }
+
+  public List<DashboardFilter> keepFiltersAllowedByPolicy(List<DashboardFilter> filters) {
+    return filters.stream()
+        .filter(Objects::nonNull)
+        .filter(this::isFilterAllowedByPolicy)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<FilterOperator> resolveEffectiveOperators(DashboardFilter filter) {
+    List<FilterOperator> globalEffective = super.resolveEffectiveOperators(filter);
+
+    if (this.hasNoWidgetPolicyForField(filter.getField())) {
+      return globalEffective;
+    }
+
+    Set<FilterOperator> widgetAllowed = widgetPolicy.getAllowedOperators(filter.getField());
+    return globalEffective.stream()
+        .filter(widgetAllowed::contains)
+        .collect(Collectors.toList());
+  }
+}

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
@@ -47,11 +47,15 @@
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/defaultValue')}"
             filterBy="#{setting.defaultValue}" filterMatchMode="contains" styleClass="settings-table-default-value-column">
-            <h:outputText value="#{setting.defaultValue}" />
+            <h:panelGroup layout="block" styleClass="block w-full u-truncate-text">
+              <h:outputText value="#{setting.defaultValue}" />
+            </h:panelGroup>
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/currentValue')}"
             filterBy="#{setting.displayValue}" filterMatchMode="contains" styleClass="settings-table-current-value-column">
-            <h:outputText value="#{setting.displayValue}" />
+            <h:panelGroup layout="block" styleClass="block w-full u-truncate-text">
+              <h:outputText value="#{setting.displayValue}" />
+            </h:panelGroup>
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/note')}"
             filterBy="#{setting.note}" filterMatchMode="contains">
@@ -172,21 +176,23 @@
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'SELECTION'}">
-              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="value-setting-dropdown">
+              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="w-full">
                 <f:selectItems value="#{data.dropDownValues}" var="value" itemLabel="#{adminSettingBean.getDropdownItemlabel(value)}" />
               </p:selectOneMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'EXTERNAL_SELECTION'}">
-              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="value-setting-dropdown">
+              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="w-full">
                 <f:selectItems value="#{data.externalDropDownValues.entrySet()}" var="entry" itemValue="#{entry.key}" itemLabel="#{data.selectedSetting.key eq 'Portal.Homepage' ? entry.value : entry.value.getLabel()}" />
               </p:selectOneMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'MULTI_EXTERNAL_SELECTIONS'}">
-              <p:selectManyCheckbox value="#{data.selectedMultiSettings}" id="valueSetting">
+              <p:selectCheckboxMenu id="valueSetting" value="#{data.selectedMultiSettings}"
+                updateLabel="true" filter="true" panelStyleClass="value-setting-dropdown-panel"
+                styleClass="w-full" scrollHeight="250">
                 <f:selectItems value="#{data.externalDropDownValues.entrySet()}" var="entry" itemValue="#{entry.key}" itemLabel="#{entry.value.getLabel()}" />
-              </p:selectManyCheckbox>
+              </p:selectCheckboxMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'PASSWORD'}">


### PR DESCRIPTION
In general, introduce 2-level configuration to control filter operators (e.g. equals, contains, starts with) are available.
- admin setting through `Portal.ComplexFilter.Operators` variable.
<img width="1830" height="850" alt="image" src="https://github.com/user-attachments/assets/803358de-ffff-40ce-8fb5-5bf1ec9c3bf6" />

- per-widget config in the column management dialog (but cannot re-enable if being disabled in admin setting).
<img width="1880" height="860" alt="image" src="https://github.com/user-attachments/assets/fbfd4ebe-2235-47ed-b561-e45850fbc0a7" />

-----

This PR:

- Add domain models `GlobalOperatorPolicy` and `OperatorPolicy` to represent global and per-widget operator constraints
- Add `GlobalOperatorPolicyProvider` and `WidgetOperatorPolicyProvider` to read and build policy from configuration and column definitions
- Add `BaselineOperatorService` to resolve the default available operators per column and filter field
- Add `GlobalOperatorPolicyService` and `OperatorPolicyService` to apply global and widget-level policy filtering and operator resolution
- Admins can now configure which filter operators are globally enabled via a new `Portal.ComplexFilter.Operators` multi-select in Admin Settings
- Replace `p:selectManyCheckbox` with `p:selectCheckboxMenu` in `AdminSettings.xhtml` for better UX on multi-select settings
