### PR TITLE
IVYPORTAL-20522 Add global operator policy admin setting

### DIFF
--- a/AxonIvyPortal/portal/cms/cms.yaml
+++ b/AxonIvyPortal/portal/cms/cms.yaml
@@ -163,6 +163,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Set URL to download Axon Ivy mobile app on Apple Store.
       BaseQRCodeUrl: Set Base URL for QR code to display.
       GooglePlayURL: Set URL to download Axon Ivy mobile app on Google Play.
+      DashboardFilterOperatorPolicy: Unchecked operators are disabled globally.
       behaviourWhenClickingOnLineInCaseList: Toggle between accessing case details or business details when clicking on a case in the case widget on the dashboard, global search, related cases, and process widget in combined mode.
       behaviourWhenClickingOnLineInTaskList: For switch behaviours (run the task or access task details) when clicking on a line in task list, task widget of dashboard and related tasks  in case details page.
       chatMaxConnection: 'The set number controls the amount of tabs allowed with active chat. If more tabs are opened, the chat will be disabled in inactive tabs. Allowed values between 1-5 '
@@ -590,6 +591,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     EmptyFilterMessage: No widget filter found
     Filter:
       FilterOptionHeader: Filter options
+      FilterOptionHeaderTooltip: Some filter fields and operators may be disabled by your administrator. Filters using disabled fields or operators will be automatically removed. Please contact your administrator for more information.
       FilterPanelHeader: Filter panel
       ManageWidgetFilterHeader: Widget filter management
       NotFound: No filter found
@@ -668,6 +670,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
+    operators: Operators
+    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms_de.yaml
+++ b/AxonIvyPortal/portal/cms/cms_de.yaml
@@ -220,6 +220,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Legen Sie die URL für den Download der Axon Ivy Mobile App im Apple Store fest.
       ApplicationName: Der Name der Anwendung, der auf dem Seitentitel angezeigt werden soll.
       BaseQRCodeUrl: Legen Sie die Basis-URL für den anzuzeigenden QR-Code fest.
+      DashboardFilterOperatorPolicy: Nicht ausgewählte Operatoren werden global deaktiviert.
       DefaultThemeMode: Der Standardthemenmodus der Anwendung
       EnableSwitchThemeModeButton: Setzen Sie diesen Wert auf true, um die Schaltfläche "Thema wechseln" zu aktivieren.
       GlobalSearchScopeCategoriesNote: Festlegung der Typen, nach denen bei der globalen Suche gesucht werden soll
@@ -830,6 +831,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Dieses Widget kann eine externe Webseite anzeigen.
     Filter:
       FilterOptionHeader: Filter-Optionen
+      FilterOptionHeaderTooltip: Einige Filterfelder und Operatoren wurden möglicherweise von Ihrem Administrator deaktiviert. Filter, die deaktivierte Felder oder Operatoren verwenden, werden automatisch entfernt. Bitte wenden Sie sich an Ihren Administrator für weitere Informationen.
       FilterPanelHeader: Filterbereich
       ManageWidgetFilterHeader: Widget-Filter-Verwaltung
       NotFound: Kein Filter gefunden
@@ -974,6 +976,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Sie haben keine Berechtigung, Dashboards zu sehen.
     noWidget: Es sind aktuell keine Widgets auf diesem Dashboard vorhanden
     numberPattern: Zahlen-Muster
+    operators: Operatoren
+    operatorPolicyTooltip: Wenn Operatoren vom Administrator global deaktiviert sind, können sie hier nicht aktiviert werden. Der Filter eines Felds kann nicht aktiviert werden, wenn alle Operatoren global deaktiviert sind.
     preview: Vorschau
     processList: Prozessliste
     processListIntroduction: Dieses Widget zeigt verfügbare Prozessstarts an. Sie haben die Möglichkeit, unterschiedliche Formate zu wählen

--- a/AxonIvyPortal/portal/cms/cms_en.yaml
+++ b/AxonIvyPortal/portal/cms/cms_en.yaml
@@ -221,6 +221,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Set URL to download Axon Ivy mobile app on Apple Store.
       ApplicationName: The application name that will be displayed on the page title.
       BaseQRCodeUrl: Set Base URL for QR code to display.
+      DashboardFilterOperatorPolicy: Unchecked operators are disabled globally.
       DefaultThemeMode: The default theme mode of the application
       EnableSwitchThemeModeButton: Set to true to enable the switch theme button.
       GlobalSearchScopeCategoriesNote: Defining the types that the global search will search for
@@ -826,6 +827,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: This widget can display an external webpage.
     Filter:
       FilterOptionHeader: Filter options
+      FilterOptionHeaderTooltip: Some filter fields and operators may be disabled by your administrator. Filters using disabled fields or operators will be automatically removed. Please contact your administrator for more information.
       FilterPanelHeader: Filter panel
       ManageWidgetFilterHeader: Widget filter management
       NotFound: No filter found
@@ -970,6 +972,9 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: You don't have permissions to see dashboards.
     noWidget: There are no widgets provided for this dashboard
     numberPattern: Number Pattern
+    operators: Operators
+    operatorPolicyTooltip: If operators are disabled globally by admin, they can't be enabled here. A field filter can't be enabled when all operators are globally disabled.
+    operatorPolicyInvalid: 'Some selected operators are disabled by global configuration. Please review: {0}'
     preview: Preview
     processList: Process List
     processListIntroduction: This widget displays available process starts. You have the possibility to choose different formats.

--- a/AxonIvyPortal/portal/cms/cms_es.yaml
+++ b/AxonIvyPortal/portal/cms/cms_es.yaml
@@ -220,6 +220,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Establezca la URL para descargar la aplicación móvil Axon Ivy en Apple Store.
       ApplicationName: El nombre de la aplicación que se mostrará en el título de la página.
       BaseQRCodeUrl: Establezca la URL base para mostrar el código QR.
+      DashboardFilterOperatorPolicy: Los operadores no marcados se deshabilitan globalmente.
       DefaultThemeMode: El modo de tema por defecto de la aplicación
       EnableSwitchThemeModeButton: Establecer en true para habilitar el botón de cambio de tema.
       GlobalSearchScopeCategoriesNote: Definición de los tipos que buscará la búsqueda global
@@ -828,6 +829,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Este widget puede mostrar una página web externa.
     Filter:
       FilterOptionHeader: Opciones de filtro
+      FilterOptionHeaderTooltip: Algunos campos de filtro y operadores pueden estar deshabilitados por su administrador. Los filtros que utilicen campos u operadores deshabilitados se eliminarán automáticamente. Comuníquese con su administrador para obtener más información.
       FilterPanelHeader: Panel de filtro
       ManageWidgetFilterHeader: Gestión de filtros de widgets
       NotFound: No se ha encontrado ningún filtro
@@ -972,6 +974,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: No tienes permisos para ver los dashboards.
     noWidget: No hay widgets para este tablero
     numberPattern: Patrón de números
+    operators: Operadores
+    operatorPolicyTooltip: Si los operadores están deshabilitados globalmente por el administrador, no pueden habilitarse aquí. El filtro de un campo no puede habilitarse cuando todos los operadores están deshabilitados globalmente.
     preview: Vista previa
     processList: Lista de procesos
     processListIntroduction: Este widget muestra los inicios de procesos disponibles. Tiene la posibilidad de elegir diferentes formatos

--- a/AxonIvyPortal/portal/cms/cms_fr.yaml
+++ b/AxonIvyPortal/portal/cms/cms_fr.yaml
@@ -220,6 +220,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Définir l'URL pour télécharger l'application mobile Axon Ivy sur l'Apple Store.
       ApplicationName: Le nom de l'application qui sera affiché dans le titre de la page.
       BaseQRCodeUrl: Définir l'URL de base du code QR à afficher.
+      DashboardFilterOperatorPolicy: Les opérateurs décochés sont désactivés globalement.
       DefaultThemeMode: Le mode de thème par défaut de l'application
       EnableSwitchThemeModeButton: Défini à true pour activer le bouton de changement de thème.
       GlobalSearchScopeCategoriesNote: Définition des types recherchés par la recherche globale
@@ -828,6 +829,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: Ce widget peut afficher une page web externe.
     Filter:
       FilterOptionHeader: Options de filtre
+      FilterOptionHeaderTooltip: Certains champs de filtre et opérateurs peuvent être désactivés par votre administrateur. Les filtres utilisant des champs ou des opérateurs désactivés seront automatiquement supprimés. Veuillez contacter votre administrateur pour plus d'informations.
       FilterPanelHeader: Panneau de filtre
       ManageWidgetFilterHeader: Gestion des filtres des widgets
       NotFound: Aucun filtre trouvé
@@ -972,6 +974,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: Vous n'avez pas les permissions pour voir les tableaux de bord.
     noWidget: Il n'y a pas de widgets fournis pour ce tableau de bord.
     numberPattern: Modèle de numéro
+    operators: Opérateurs
+    operatorPolicyTooltip: Si les opérateurs sont désactivés globalement par l'administrateur, ils ne peuvent pas être activés ici. Le filtre d'un champ ne peut pas être activé lorsque tous les opérateurs sont désactivés globalement.
     preview: Aperçu
     processList: Liste des processus
     processListIntroduction: Ce widget montre les démarrages de processus disponibles. Vous avez la possibilité de choisir différents formats

--- a/AxonIvyPortal/portal/cms/cms_ja.yaml
+++ b/AxonIvyPortal/portal/cms/cms_ja.yaml
@@ -221,6 +221,7 @@ ch.ivy.addon.portalkit.ui.jsf:
       AppleStoreURL: Apple Store で Axon Ivy モバイル アプリをダウンロードするための URL を設定します。
       ApplicationName: ページタイトルに表示されるアプリケーション名。
       BaseQRCodeUrl: 表示するQRコードのベースURLを設定します。
+      DashboardFilterOperatorPolicy: 未選択の演算子はグローバルで無効になります。
       DefaultThemeMode: アプリケーションのテーマモードの初期値
       EnableDocumentPreview: ドキュメントのプレビューを有効にするには true に設定してください。（プレビュー可能なファイルの種類：pdf、png、txt、log）
       EnableSwitchThemeModeButton: テーマ切り替えボタンを有効にするには true に設定してください。
@@ -827,6 +828,7 @@ ch.ivy.addon.portalkit.ui.jsf:
     ExternalPageWidgetIntroduction: このウィジェットは外部Webページを表示できます。
     Filter:
       FilterOptionHeader: フィルターオプション
+      FilterOptionHeaderTooltip: 一部のフィルターフィールドや演算子は管理者によって無効化されている場合があります。無効なフィールドまたは演算子を使用しているフィルターは自動的に削除されます。詳細については管理者にお問い合わせください。
       FilterPanelHeader: フィルターパネル
       ManageWidgetFilterHeader: ウィジェットフィルター管理
       NotFound: フィルターが見つかりません
@@ -971,6 +973,8 @@ ch.ivy.addon.portalkit.ui.jsf:
     noPermission: ダッシュボードを表示する権限がありません。
     noWidget: このダッシュボードにはウィジェットが用意されていません
     numberPattern: 番号パターン
+    operators: オペレーター
+    operatorPolicyTooltip: オペレーターが管理者によってグローバルに無効化されている場合、ここで有効化することはできません。すべてのオペレーターがグローバルに無効化されている場合、フィールドのフィルターを有効化することはできません。
     preview: プレビュー
     processList: プロセスリスト
     processListIntroduction: このウィジェットには、利用可能なプロセス開始が表示されます。さまざまな形式を選択できます。

--- a/AxonIvyPortal/portal/config/variables.yaml
+++ b/AxonIvyPortal/portal/config/variables.yaml
@@ -62,6 +62,9 @@ Variables:
       # You can customize the name and icon of the main menu entry for Portal dashboards via this JSON file.
       # [file: json]
       MainMenuEntry: ""
+    # Configure enabled operators for complex filters as comma-separated enum names.
+    ComplexFilter:
+      Operators: TODAY,YESTERDAY,IS,IS_NOT,BEFORE,AFTER,BETWEEN,NOT_BETWEEN,CURRENT,LAST,NEXT,EMPTY,NOT_EMPTY,CONTAINS,NOT_CONTAINS,IN,NOT_IN,START_WITH,NOT_START_WITH,END_WITH,NOT_END_WITH,CURRENT_USER_CAN_WORK_ON,CURRENT_USER,NO_CATEGORY,EQUAL,NOT_EQUAL,LESS,LESS_OR_EQUAL,GREATER,GREATER_OR_EQUAL
     Processes:
       # The standard setting of view mode in the process list.
       # [enum: COMPACT, IMAGE, GRID]

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/GlobalSetting.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/configuration/GlobalSetting.java
@@ -13,6 +13,7 @@ import com.axonivy.portal.enums.SearchScopeCaseField;
 import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.enums.SidebarMode;
 import com.axonivy.portal.enums.ThemeMode;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -126,6 +127,7 @@ public class GlobalSetting extends AbstractConfiguration {
       case GlobalSearchScopeCategory castObject -> castObject.getLabel();
       case DelegationAppendOption castObject -> castObject.getLabel();
       case SidebarMode castObject -> castObject.getLabel();
+      case FilterOperator castObject -> castObject.getLabel();
       default -> (String) object;
     };
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/enums/GlobalVariable.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/enums/GlobalVariable.java
@@ -16,6 +16,7 @@ import com.axonivy.portal.enums.SearchScopeCaseField;
 import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.enums.SidebarMode;
 import com.axonivy.portal.enums.ThemeMode;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 
 import ch.addon.portal.generic.userprofile.homepage.HomepageType;
 import ch.ivy.addon.portalkit.document.DocumentExtensionConstants;
@@ -95,7 +96,9 @@ public enum GlobalVariable {
       "enablePinCase"),ALLOW_KEYBOARD_SHORTCUTS_CONFIGURATION(
           "Portal.Accessibility.AllowKeyboardShortcutsConfiguration", GlobalVariableType.SELECTION, Option.TRUE.toString(), "allowKeyboardShortcutsConfiguration"),
   SIDEBAR_MODE("Portal.Sidebar.Mode", GlobalVariableType.EXTERNAL_SELECTION, SidebarMode.HOVER.name(), "sidebarMode", getSidebarModes()),
-  MAXIMUM_SELECTED_TASKS("Portal.Tasks.MaximumSelectedTasks", GlobalVariableType.NUMBER, "20", "maximumSelectedTasks");
+  MAXIMUM_SELECTED_TASKS("Portal.Tasks.MaximumSelectedTasks", GlobalVariableType.NUMBER, "20", "maximumSelectedTasks"),
+  FILTER_OPERATOR_POLICY("Portal.ComplexFilter.Operators", GlobalVariableType.MULTI_EXTERNAL_SELECTIONS,
+      getFilterOperatorOptions(), "DashboardFilterOperatorPolicy", getFilterOperatorOptions());
 
   private String key;
   private GlobalVariableType type;
@@ -302,6 +305,14 @@ public enum GlobalVariable {
     Map<String, Object> result = new HashMap<>();
     for (SidebarMode mode : SidebarMode.values()) {
       result.put(mode.name(), mode);
+    }
+    return result;
+  }
+
+  private static Map<String, Object> getFilterOperatorOptions() {
+    Map<String, Object> result = new LinkedHashMap<>();
+    for (FilterOperator operator : FilterOperator.values()) {
+      result.put(operator.name(), operator);
     }
     return result;
   }

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
@@ -47,11 +47,15 @@
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/defaultValue')}"
             filterBy="#{setting.defaultValue}" filterMatchMode="contains" styleClass="settings-table-default-value-column">
-            <h:outputText value="#{setting.defaultValue}" />
+            <h:panelGroup layout="block" styleClass="block w-full u-truncate-text">
+              <h:outputText value="#{setting.defaultValue}" />
+            </h:panelGroup>
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/currentValue')}"
             filterBy="#{setting.displayValue}" filterMatchMode="contains" styleClass="settings-table-current-value-column">
-            <h:outputText value="#{setting.displayValue}" />
+            <h:panelGroup layout="block" styleClass="block w-full u-truncate-text">
+              <h:outputText value="#{setting.displayValue}" />
+            </h:panelGroup>
           </p:column>
           <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/adminSettings/note')}"
             filterBy="#{setting.note}" filterMatchMode="contains">
@@ -172,21 +176,23 @@
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'SELECTION'}">
-              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="value-setting-dropdown">
+              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="w-full">
                 <f:selectItems value="#{data.dropDownValues}" var="value" itemLabel="#{adminSettingBean.getDropdownItemlabel(value)}" />
               </p:selectOneMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'EXTERNAL_SELECTION'}">
-              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="value-setting-dropdown">
+              <p:selectOneMenu value="#{data.selectedSetting.value}" id="valueSetting" styleClass="w-full">
                 <f:selectItems value="#{data.externalDropDownValues.entrySet()}" var="entry" itemValue="#{entry.key}" itemLabel="#{data.selectedSetting.key eq 'Portal.Homepage' ? entry.value : entry.value.getLabel()}" />
               </p:selectOneMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'MULTI_EXTERNAL_SELECTIONS'}">
-              <p:selectManyCheckbox value="#{data.selectedMultiSettings}" id="valueSetting">
+              <p:selectCheckboxMenu id="valueSetting" value="#{data.selectedMultiSettings}"
+                updateLabel="true" filter="true" panelStyleClass="value-setting-dropdown-panel"
+                styleClass="w-full" scrollHeight="250">
                 <f:selectItems value="#{data.externalDropDownValues.entrySet()}" var="entry" itemValue="#{entry.key}" itemLabel="#{entry.value.getLabel()}" />
-              </p:selectManyCheckbox>
+              </p:selectCheckboxMenu>
             </c:if>
             
             <c:if test="#{data.settingInputType.toString() == 'PASSWORD'}">


### PR DESCRIPTION
- Admins can now configure which filter operators are globally enabled via a new `Portal.ComplexFilter.Operators` multi-select in Admin Settings
- Replace `p:selectManyCheckbox` with `p:selectCheckboxMenu` in `AdminSettings.xhtml` for better UX on multi-select settings
