### PR TITLE
IVYPORTAL-20653 Empty CODEONWERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*  @axonivy-market/team-wawa


### PR DESCRIPTION
Current CODEOWNERS entry is the whole team, so it spam the team without bringing much value.
This PR empty the file, then later we could add entries for related topics.
