### PR TITLE
IVYPORTAL-20522 Config operators per widget and enforce rule to runtime dashboard filters

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -25,7 +26,10 @@ import org.apache.commons.lang3.Strings;
 
 import com.axonivy.portal.components.util.FacesMessageUtils;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.axonivy.portal.service.IvyTranslationService;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
+import com.axonivy.portal.service.filter.operatorpolicy.service.OperatorPolicyService;
 
 import ch.ivy.addon.portalkit.dto.DisplayName;
 import ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget;
@@ -56,6 +60,7 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
 
   private static final long serialVersionUID = -4406460802168467529L;
   private static final String NO_CATEGORY_CMS = "/ch.ivy.addon.portalkit.ui.jsf/common/noCategory";
+  private static final String HAS_CMS_VALUES_ATTRIBUTE = "HasCmsValues";
 
   private DashboardWidget widget;
   private List<ColumnModel> columnsBeforeSave;
@@ -75,6 +80,7 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
   private boolean isConfiguredLanguage;
   private String warningText;
   private String translatedText;
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
 
   public void init() {
     this.fieldTypes = Arrays.asList(DashboardColumnType.STANDARD, DashboardColumnType.CUSTOM);
@@ -99,6 +105,7 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
       CaseDashboardWidget caseDashboardWidget = (CaseDashboardWidget) this.widget;
       this.columnsBeforeSave = new ArrayList<>(caseDashboardWidget.getColumns());
     }
+    applyOperatorPolicyToColumns(this.columnsBeforeSave);
   }
 
   private void resetValues() {
@@ -146,36 +153,36 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
     Set<String> enabledFilterFields = Optional.ofNullable(taskWidget.getFilterableColumns()).orElse(Collections.emptyList())
       .stream().map(ColumnModel::getField)
       .collect(Collectors.toSet());
-
+    OperatorPolicyService opPolicyService = new OperatorPolicyService(taskWidget.getFilterableColumns());
     List<DashboardFilter> filterToKeep = taskWidget.getFilters().stream()
         .filter(filter -> enabledFilterFields.contains(filter.getField()))
         .collect(Collectors.toList());
 
-    taskWidget.setFilters(filterToKeep);
+    taskWidget.setFilters(opPolicyService.keepFiltersAllowedByPolicy(filterToKeep));
 
     List<DashboardFilter> userFilterToKeep = taskWidget.getUserFilters().stream()
         .filter(filter -> enabledFilterFields.contains(filter.getField()))
         .collect(Collectors.toList());
 
-    taskWidget.setUserFilters(userFilterToKeep);
+    taskWidget.setUserFilters(opPolicyService.keepFiltersAllowedByPolicy(userFilterToKeep));
   }
 
   private void updateFiltersForCaseWidget(CaseDashboardWidget caseWidget) {
     Set<String> enabledFilterFields = Optional.ofNullable(caseWidget.getFilterableColumns()).orElse(Collections.emptyList())
         .stream().map(ColumnModel::getField)
         .collect(Collectors.toSet());
-
+    OperatorPolicyService opPolicyService = new OperatorPolicyService(caseWidget.getFilterableColumns());
     List<DashboardFilter> filterToKeep = caseWidget.getFilters().stream()
         .filter(filter -> enabledFilterFields.contains(filter.getField()))
         .collect(Collectors.toList());
 
-    caseWidget.setFilters(filterToKeep);
+    caseWidget.setFilters(opPolicyService.keepFiltersAllowedByPolicy(filterToKeep));
 
     List<DashboardFilter> userFilterToKeep = caseWidget.getUserFilters().stream()
         .filter(filter -> enabledFilterFields.contains(filter.getField()))
         .collect(Collectors.toList());
 
-    caseWidget.setUserFilters(userFilterToKeep);
+    caseWidget.setUserFilters(opPolicyService.keepFiltersAllowedByPolicy(userFilterToKeep));
   }
   
   public void remove(ColumnModel col) {
@@ -234,11 +241,13 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
       columnModel.setType(selectedFieldType);
       columnModel.setFormat(DashboardColumnFormat.valueOf(selectedFieldType.name()));
       columnModel.setPattern(numberFieldPattern);
+      columnModel.setHasCmsValues(findCustomFieldMeta().map(meta -> Boolean.valueOf(meta.attribute(HAS_CMS_VALUES_ATTRIBUTE))).orElse(false));
     }
     if (this.selectedFieldType == DashboardColumnType.CUSTOM_CASE
         || this.selectedFieldType == DashboardColumnType.CUSTOM_BUSINESS_CASE) {
       columnModel.setSortable(null);
     }
+    applyOperatorPolicyToColumn(columnModel);
     this.columnsBeforeSave.add(columnModel);
     this.fields.remove(columnModel.getField());
     FacesMessage msg = FacesMessageUtils.sanitizedMessage(FacesMessage.SEVERITY_INFO,
@@ -455,7 +464,93 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
   }
 
   public void handleFilter(ColumnModel column) {
-    column.setEnableFilter(BooleanUtils.isFalse(column.getEnableFilter()));
+    if (column == null || !column.canFilter()) {
+      return;
+    }
+
+    boolean enableFilter = BooleanUtils.isFalse(column.getEnableFilter());
+    column.setEnableFilter(enableFilter);
+
+    if (enableFilter && CollectionUtils.isEmpty(column.getAllowedOperators())) {
+      column.setAllowedOperators(new ArrayList<>(getGloballyEffectiveOperators(column)));
+    }
+  }
+
+  public boolean isFilterToggleDisabled(ColumnModel column) {
+    if (column == null || !column.canFilter()) {
+      return true;
+    }
+    return getGloballyEffectiveOperators(column).isEmpty();
+  }
+
+  public List<FilterOperator> getAvailableOperators(ColumnModel column) {
+    return globalOperatorPolicyService.getBaselineOperatorService().resolveForColumn(column);
+  }
+
+  public boolean isOperatorGloballyEnabled(FilterOperator op) {
+    return globalOperatorPolicyService.isOperatorGloballyEnabled(op);
+  }
+
+  public void onOperatorSelectionChange(ColumnModel column) {
+    if (column == null || !column.canFilter()) {
+      return;
+    }
+
+    if (CollectionUtils.isEmpty(column.getAllowedOperators())) {
+      column.setEnableFilter(false);
+    }
+  }
+
+  public String operatorCountingLabel(ColumnModel column) {
+    List<FilterOperator> availableOperators = getAvailableOperators(column);
+    int total = CollectionUtils.size(availableOperators);
+    int selected = CollectionUtils.size(column.getAllowedOperators());
+    return selected + "/" + total;
+  }
+
+  private void applyOperatorPolicyToColumns(List<ColumnModel> columns) {
+    if (CollectionUtils.isEmpty(columns)) {
+      return;
+    }
+
+    columns.stream().filter(Objects::nonNull).filter(ColumnModel::canFilter).forEach(this::applyOperatorPolicyToColumn);
+  }
+
+  private void applyOperatorPolicyToColumn(ColumnModel column) {
+    if (column == null || !column.canFilter()) {
+      return;
+    }
+
+    List<FilterOperator> enabledAvailableOperators = getGloballyEffectiveOperators(column);
+    if (enabledAvailableOperators.isEmpty()) {
+      column.setAllowedOperators(new ArrayList<>());
+      column.setEnableFilter(false);
+      return;
+    }
+
+    if (column.getAllowedOperators() == null) {
+      column.setAllowedOperators(new ArrayList<>(enabledAvailableOperators));
+      return;
+    }
+
+    List<FilterOperator> selectedOperators = sanitizeSelectedOperators(column.getAllowedOperators(), enabledAvailableOperators);
+    column.setAllowedOperators(selectedOperators);
+    if (selectedOperators.isEmpty()) {
+      column.setEnableFilter(false);
+    }
+  }
+
+  private List<FilterOperator> sanitizeSelectedOperators(List<FilterOperator> selectedOperators, List<FilterOperator> enabledAvailableOperators) {
+    if (CollectionUtils.isEmpty(selectedOperators)) {
+      return new ArrayList<>();
+    }
+
+    return selectedOperators.stream().filter(enabledAvailableOperators::contains)
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  private List<FilterOperator> getGloballyEffectiveOperators(ColumnModel column) {
+    return globalOperatorPolicyService.keepGloballyEnabledOperators(getAvailableOperators(column));
   }
   
   public List<DisplayName> getFieldDisplayNames() {

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
@@ -239,7 +239,9 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
         || this.selectedFieldType == DashboardColumnType.CUSTOM_CASE
         || this.selectedFieldType == DashboardColumnType.CUSTOM_BUSINESS_CASE) {
       columnModel.setType(selectedFieldType);
-      columnModel.setFormat(DashboardColumnFormat.valueOf(selectedFieldType.name()));
+      var format = findCustomFieldMeta().filter(meta -> meta.name().equals(this.selectedField)).map(ICustomFieldMeta::type)
+        .map(type -> DashboardColumnFormat.valueOf(type.name()));
+      columnModel.setFormat(format.orElse(DashboardColumnFormat.valueOf(selectedFieldType.name())));
       columnModel.setPattern(numberFieldPattern);
       columnModel.setHasCmsValues(findCustomFieldMeta().map(meta -> Boolean.valueOf(meta.attribute(HAS_CMS_VALUES_ATTRIBUTE))).orElse(false));
     }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
@@ -502,8 +502,10 @@ public class ColumnManagementBean implements Serializable, IMultiLanguage {
   }
 
   public String operatorCountingLabel(ColumnModel column) {
-    List<FilterOperator> availableOperators = getAvailableOperators(column);
-    int total = CollectionUtils.size(availableOperators);
+    if (column == null) {
+      return "0/0";
+    }
+    int total = CollectionUtils.size(getAvailableOperators(column));
     int selected = CollectionUtils.size(column.getAllowedOperators());
     return selected + "/" + total;
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/WidgetFilterService.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/service/WidgetFilterService.java
@@ -14,6 +14,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.commons.lang3.math.NumberUtils;
 
+import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.service.filter.operatorpolicy.service.OperatorPolicyService;
+
 import ch.ivy.addon.portalkit.bean.WidgetFilterHelperBean;
 import ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget;
 import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
@@ -107,6 +110,7 @@ public class WidgetFilterService extends JsonConfigurationService<WidgetFilterMo
 
 
   public void applyUserFilterFromSession(DashboardWidget widget) {
+    removeDisabledPredefinedFilters(widget);
     var selectedFilterObject = Ivy.session().getAttribute(buildWidgetKey(widget.getId(), widget.getType()));
     var userFilterCollection = BusinessEntityConverter.jsonValueToEntity(String.valueOf(selectedFilterObject), UserFilterCollection.class);
     if (userFilterCollection == null) {
@@ -318,35 +322,50 @@ public class WidgetFilterService extends JsonConfigurationService<WidgetFilterMo
       .ifPresent(latestFilterOption -> removeDisabledUserFilters(latestFilterOption, widget.getType(), enabledColumns));
   }
 
-  private static List<ColumnModel> getEnabledFilterableColumns(DashboardWidget widget) {
-    switch (widget.getType()) {
-      case TASK:
-        return ((TaskDashboardWidget) widget).getFilterableColumns();
-      case CASE:
-        return ((CaseDashboardWidget) widget).getFilterableColumns();
-      default:
-        return new ArrayList<>();
-    }
+  public static List<ColumnModel> getEnabledFilterableColumns(DashboardWidget widget) {
+    List<ColumnModel> columns = getFilterableColumns(widget);
+    return new OperatorPolicyService(columns).getColumnsWithGloballyEnabledOperators(columns);
   }
 
-  public static void removeDisabledFilters(TaskDashboardWidget widget) {
-    List<String> enabledColumns = getEnabledFilterableColumns(widget).stream().map(ColumnModel::getField).toList();
-    widget.getUserFilters().removeIf(userFilter -> !enabledColumns.contains(userFilter.getField()));
+  private static List<ColumnModel> getFilterableColumns(DashboardWidget widget) {
+    return switch (widget.getType()) {
+        case TASK -> ((TaskDashboardWidget) widget).getFilterableColumns();
+        case CASE -> ((CaseDashboardWidget) widget).getFilterableColumns();
+        default -> new ArrayList<>();
+    };
+  }
+
+  public static void pruneInvalidUserFilters(TaskDashboardWidget widget) {
+    widget.setUserFilters(retainFiltersValidByPolicy(widget, widget.getUserFilters()));
   }
 
   public static void removeDisabledFilters(CaseDashboardWidget widget) {
-    List<String> enabledColumns = getEnabledFilterableColumns(widget).stream().map(ColumnModel::getField).toList();
-    widget.getUserFilters().removeIf(userFilter -> !enabledColumns.contains(userFilter.getField()));
+    widget.setUserFilters(retainFiltersValidByPolicy(widget, widget.getUserFilters()));
+  }
+
+  public static void removeDisabledPredefinedFilters(DashboardWidget widget) {
+    switch (widget) {
+      case TaskDashboardWidget w -> w.setFilters(retainFiltersValidByPolicy(w, w.getFilters()));
+      case CaseDashboardWidget w -> w.setFilters(retainFiltersValidByPolicy(w, w.getFilters()));
+      default -> {}
+    }
+  }
+
+  private static List<DashboardFilter> retainFiltersValidByPolicy(DashboardWidget widget, List<DashboardFilter> userFilters) {
+    List<ColumnModel> columns = getFilterableColumns(widget);
+    return new OperatorPolicyService(columns).keepFiltersAllowedByPolicy(userFilters);
   }
 
   private void removeDisabledUserFilters(WidgetFilterModel model, DashboardWidgetType widgetType, List<ColumnModel> enabledColumns) {
     if (widgetType != DashboardWidgetType.TASK && widgetType != DashboardWidgetType.CASE) {
       return;
     }
-    model.setUserFilters(CollectionUtils.emptyIfNull(model.getUserFilters()).stream()
+    List<DashboardFilter> userFilters = CollectionUtils.emptyIfNull(model.getUserFilters()).stream()
         .filter(f -> StringUtils.isNotBlank(f.getField()))
         .filter(f -> enabledColumns.stream().anyMatch(col -> Strings.CS.equals(col.getField(), f.getField())))
-        .collect(Collectors.toList()));
+        .collect(Collectors.toList());
+    
+    model.setUserFilters(new OperatorPolicyService(enabledColumns).keepFiltersAllowedByPolicy(userFilters));
   }
 
   private String getLessValue(DashboardColumnFormat format, String selectedValueFrom, String value) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/CanWorkOnFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/CanWorkOnFilterBean.java
@@ -4,18 +4,27 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
 public class CanWorkOnFilterBean implements Serializable{
   private static final long serialVersionUID = 1L;
   
-  private static List<FilterOperator> operators = FilterOperator.STATISTIC_CAN_WORK_ON_OPERATORS.stream().toList();
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> operators;
+
+  @PostConstruct
+  public void initOperators() {
+    operators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_CAN_WORK_ON_OPERATORS.stream().toList());
+  }
 
   public List<FilterOperator> getOperators() {
     return operators;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetApplicationFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetApplicationFilterBean.java
@@ -10,7 +10,6 @@ import javax.faces.bean.ViewScoped;
 import org.apache.commons.collections4.CollectionUtils;
 
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
-import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 
 import ch.ivy.addon.portalkit.util.ListUtilities;
 import ch.ivyteam.ivy.application.IApplication;
@@ -23,7 +22,6 @@ public class WidgetApplicationFilterBean implements Serializable {
 
   private static final long serialVersionUID = 4458514225804204212L;
 
-  private static List<FilterOperator> operators = FilterOperator.APPLICATION_OPERATORS.stream().toList();
   private List<String> applications;
   private String applicationString;
 
@@ -33,10 +31,6 @@ public class WidgetApplicationFilterBean implements Serializable {
 
     this.applicationString = String.join(", ",
         new ArrayList<>(CollectionUtils.intersection(applications, filter.getValues())));
-  }
-
-  public List<FilterOperator> getOperators() {
-    return operators;
   }
 
   public List<String> getApplications() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCategoryFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCategoryFilterBean.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -14,6 +15,7 @@ import org.primefaces.model.CheckboxTreeNode;
 
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 
 import ch.ivy.addon.portalkit.bo.CategoryNode;
 import ch.ivy.addon.portalkit.constant.PortalConstants;
@@ -27,9 +29,14 @@ public class WidgetCategoryFilterBean implements Serializable {
 
   private static final long serialVersionUID = 5886200209828694569L;
 
-  private static List<FilterOperator> operators = FilterOperator.CATEGORY_OPERATORS.stream().toList();
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList();
-  
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
+
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList());
+  }
 
   private CheckboxTreeNode<CategoryNode> categoryTree;
   private CheckboxTreeNode<CategoryNode>[] selectedCategoryNodes;
@@ -42,10 +49,6 @@ public class WidgetCategoryFilterBean implements Serializable {
     if (CollectionUtils.isNotEmpty(filter.getValues())) {
       setSelectedCategoriesString(filter.getValues().stream().collect(Collectors.joining(", ")));
     }
-  }
-
-  public List<FilterOperator> getOperators() {
-    return operators;
   }
 
   public List<FilterOperator> getStatisticOperators() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCreatorFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetCreatorFilterBean.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -17,6 +18,7 @@ import org.primefaces.event.UnselectEvent;
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -25,9 +27,15 @@ public class WidgetCreatorFilterBean implements Serializable {
   private static final long serialVersionUID = -2641889624945089060L;
   public static final String FILTER = "filter";
 
-  private static List<FilterOperator> operators = FilterOperator.CREATOR_OPERATORS.stream().toList();
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_CREATOR_OPERATORS.stream().toList();
-  
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
+
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_CREATOR_OPERATORS.stream().toList());
+  }
+
   private List<SecurityMemberDTO> selectedCreators;
 
   public void init(BaseFilter filter) {
@@ -37,10 +45,6 @@ public class WidgetCreatorFilterBean implements Serializable {
     }
   }
 
-  public List<FilterOperator> getOperators() {
-    return operators;
-  }
-  
   public List<FilterOperator> getStatisticOperators() {
     return statisticOperators;
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetDateFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetDateFilterBean.java
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -13,6 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 import com.axonivy.portal.enums.dashboard.filter.FilterPeriodType;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterFieldFactory;
 import com.axonivy.portal.util.filter.field.TaskFilterFieldFactory;
 
@@ -27,19 +29,19 @@ public class WidgetDateFilterBean implements Serializable {
 
   private static final long serialVersionUID = 4356531402161360729L;
 
-  private static List<FilterOperator> operators = FilterOperator.DATE_OPERATORS.stream().toList();
-  private static List<FilterOperator> createdDateOperators = FilterOperator.CREATED_DATE_OPERATORS.stream().toList();
-
   private static FilterPeriodType[] filterPeriodTypes = FilterPeriodType.values();
   private static List<FilterPeriodType> currentFilterPeriodTypes = FilterPeriodType.PERIOD_TYPES_FOR_CURRENT_OPERATOR
       .stream().toList();
 
   private static SimpleDateFormat formatter = new SimpleDateFormat(BaseFilter.DATE_FORMAT);
   
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_DATE_OPERATORS.stream().toList();
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
 
-  public List<FilterOperator> getOperators() {
-    return operators;
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_DATE_OPERATORS.stream().toList());
   }
 
   public FilterPeriodType[] getFilterPeriodTypes() {
@@ -94,10 +96,6 @@ public class WidgetDateFilterBean implements Serializable {
     }
   }
 
-  public List<FilterOperator> getCreatedDateOperators() {
-    return createdDateOperators;
-  }
-  
   public List<FilterOperator> getStatisticOperators() {
     return statisticOperators;
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetIdFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetIdFilterBean.java
@@ -1,25 +1,17 @@
 package com.axonivy.portal.bean.dashboard;
 
 import java.io.Serializable;
-import java.util.List;
 
 import javax.faces.bean.ManagedBean;
 import javax.faces.view.ViewScoped;
 
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
-import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 
 @ManagedBean
 @ViewScoped
 public class WidgetIdFilterBean implements Serializable {
 
   private static final long serialVersionUID = 4671032185665650209L;
-
-  private static List<FilterOperator> operators = FilterOperator.ID_OPERATORS.stream().toList();
-
-  public List<FilterOperator> getOperators() {
-    return operators;
-  }
 
   public void onChangeOperator(DashboardFilter filter) {
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetNumberFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetNumberFilterBean.java
@@ -12,11 +12,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -24,14 +26,15 @@ public class WidgetNumberFilterBean implements Serializable {
 
   private static final long serialVersionUID = 6088715427600445713L;
 
-  private static List<FilterOperator> operators = FilterOperator.NUMBER_OPERATORS.stream().toList();
   private static List<FilterOperator> SINGLE_FILTER_OPERATORS = Arrays.asList(EQUAL, NOT_EQUAL, LESS, LESS_OR_EQUAL,
       GREATER, GREATER_OR_EQUAL);
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_NUMBER_OPERATORS.stream().toList();
-  
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
 
-  public List<FilterOperator> getOperators() {
-    return operators;
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_NUMBER_OPERATORS.stream().toList());
   }
   
   public List<FilterOperator> getStatisticOperators() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetPriorityFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetPriorityFilterBean.java
@@ -6,11 +6,13 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 
 import ch.ivyteam.ivy.environment.Ivy;
 import ch.ivyteam.ivy.workflow.WorkflowPriority;
@@ -21,9 +23,15 @@ public class WidgetPriorityFilterBean implements Serializable {
 
   private static final long serialVersionUID = 5710087841257652703L;
 
-  private static List<FilterOperator> priorityOperators = FilterOperator.PRIORITY_OPERATORS.stream().toList();
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList();
   private static final String TASK_PRIORITY_CMS_PATH = "/ch.ivy.addon.portalkit.ui.jsf/taskPriority/";
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
+
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList());
+  }
 
   private List<String> priorities;
   private String prioritiesString;
@@ -34,10 +42,6 @@ public class WidgetPriorityFilterBean implements Serializable {
     priorities = wfPriority.stream().map(priority -> priority.name()).toList();
 
     prioritiesString = String.join(", ", filter.getValues());
-  }
-
-  public List<FilterOperator> getPriorityOperators() {
-    return priorityOperators;
   }
 
   public List<FilterOperator> getStatisticOperators() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetResponsibleFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetResponsibleFilterBean.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -17,6 +18,7 @@ import org.primefaces.event.UnselectEvent;
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 
 @ManagedBean
 @ViewScoped
@@ -25,9 +27,15 @@ public class WidgetResponsibleFilterBean implements Serializable {
   private static final long serialVersionUID = -2641889624945089060L;
   public static final String FILTER = "filter";
 
-  private static List<FilterOperator> operators = FilterOperator.RESPONSIBLE_OPERATORS.stream().toList();
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_RESPONSIBLE_OPERATORS.stream().toList();
-  
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
+
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_RESPONSIBLE_OPERATORS.stream().toList());
+  }
+
   private List<SecurityMemberDTO> selectedResponsibles;
 
   public void init(BaseFilter filter) {
@@ -37,10 +45,6 @@ public class WidgetResponsibleFilterBean implements Serializable {
     }
   }
 
-  public List<FilterOperator> getOperators() {
-    return operators;
-  }
-  
   public List<FilterOperator> getStatisticOperators() {
     return statisticOperators;
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetStateFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetStateFilterBean.java
@@ -3,6 +3,7 @@ package com.axonivy.portal.bean.dashboard;
 import java.io.Serializable;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
@@ -10,6 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 
 import ch.ivy.addon.portalkit.constant.PortalConstants;
 import ch.ivy.addon.portalkit.util.CaseUtils;
@@ -22,8 +24,14 @@ public class WidgetStateFilterBean implements Serializable {
 
   private static final long serialVersionUID = -8191354257458990196L;
 
-  private static List<FilterOperator> stateOperators = FilterOperator.STATE_OPERATORS.stream().toList();
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList();
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
+
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList());
+  }
 
   private List<String> states;
   private String statesString;
@@ -43,10 +51,6 @@ public class WidgetStateFilterBean implements Serializable {
         : "/ch.ivy.addon.portalkit.ui.jsf/businessCaseState/";
     String displayState = Ivy.cms().co(cmsUri + state.toString());
     return StringUtils.isBlank(displayState) ? state : displayState;
-  }
-
-  public List<FilterOperator> getStateOperators() {
-    return stateOperators;
   }
 
   public List<FilterOperator> getStatisticOperators() {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
@@ -41,7 +41,7 @@ public class WidgetTextFilterBean implements Serializable {
       return false;
     }
 
-    for (FilterOperator operator : getEnabledTextOperators()) {
+    for (FilterOperator operator : textOperators) {
       if (operator == FilterOperator.EMPTY || operator == FilterOperator.NOT_EMPTY) {
         continue;
       }
@@ -50,7 +50,7 @@ public class WidgetTextFilterBean implements Serializable {
       }
     }
     
-    for (FilterOperator operator : getStatisticOperators()) {
+    for (FilterOperator operator : statisticOperators) {
       if (operator == filter.getOperator()) {
         return true;
       }
@@ -68,9 +68,5 @@ public class WidgetTextFilterBean implements Serializable {
 
   public List<FilterOperator> getStatisticOperators() {
     return statisticOperators;
-  }
-
-  private List<FilterOperator> getEnabledTextOperators() {
-    return textOperators;
   }
 }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetTextFilterBean.java
@@ -1,15 +1,15 @@
 package com.axonivy.portal.bean.dashboard;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 
+import javax.annotation.PostConstruct;
 import javax.faces.bean.ManagedBean;
 import javax.faces.bean.ViewScoped;
 
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.GlobalOperatorPolicyService;
 import com.axonivy.portal.util.filter.field.caze.custom.CaseFilterFieldCustomString;
 import com.axonivy.portal.util.filter.field.task.custom.caze.TaskFilterCaseFieldCustomString;
 
@@ -21,16 +21,16 @@ public class WidgetTextFilterBean implements Serializable {
 
   private static final long serialVersionUID = 3218284115015773931L;
 
-  private static List<FilterOperator> operators = FilterOperator.TEXT_OPERATORS.stream().toList();
-  private static List<FilterOperator> operatorsForCustomFieldWithCms = Collections.unmodifiableSet(EnumSet.of(FilterOperator.CONTAINS)).stream().toList();
-  private static List<FilterOperator> statisticOperators = FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList();
+  private final GlobalOperatorPolicyService globalOperatorPolicyService = new GlobalOperatorPolicyService();
+  private List<FilterOperator> statisticOperators;
+  private List<FilterOperator> textOperators;
 
-  public List<FilterOperator> getOperators() {
-    return operators;
-  }
-  
-  public List<FilterOperator> getOperatorsForCustomFieldWithCms() {
-    return operatorsForCustomFieldWithCms;
+  @PostConstruct
+  public void initOperators() {
+    statisticOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.STATISTIC_TEXT_OPERATORS.stream().toList());
+    textOperators = globalOperatorPolicyService.keepGloballyEnabledOperators(
+        FilterOperator.TEXT_OPERATORS.stream().toList());
   }
 
   public void onChangeOperator(DashboardFilter filter) {
@@ -41,7 +41,7 @@ public class WidgetTextFilterBean implements Serializable {
       return false;
     }
 
-    for (FilterOperator operator : operators) {
+    for (FilterOperator operator : getEnabledTextOperators()) {
       if (operator == FilterOperator.EMPTY || operator == FilterOperator.NOT_EMPTY) {
         continue;
       }
@@ -50,7 +50,7 @@ public class WidgetTextFilterBean implements Serializable {
       }
     }
     
-    for (FilterOperator operator : statisticOperators) {
+    for (FilterOperator operator : getStatisticOperators()) {
       if (operator == filter.getOperator()) {
         return true;
       }
@@ -68,5 +68,9 @@ public class WidgetTextFilterBean implements Serializable {
 
   public List<FilterOperator> getStatisticOperators() {
     return statisticOperators;
+  }
+
+  private List<FilterOperator> getEnabledTextOperators() {
+    return textOperators;
   }
 }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetWorkerFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/WidgetWorkerFilterBean.java
@@ -25,8 +25,6 @@ public class WidgetWorkerFilterBean implements Serializable {
   private static final long serialVersionUID = -2641889624945089060L;
   public static final String FILTER = "filter";
 
-  private static List<FilterOperator> operators = FilterOperator.WORKER_OPERATORS.stream().toList();
-
   private List<SecurityMemberDTO> selectedWorkers;
 
   public void init(DashboardFilter filter) {
@@ -34,10 +32,6 @@ public class WidgetWorkerFilterBean implements Serializable {
     if (CollectionUtils.isNotEmpty(filter.getValues())) {
       selectedWorkers.addAll(filter.findAllUsers());
     }
-  }
-
-  public List<FilterOperator> getOperators() {
-    return operators;
   }
 
   public void onChangeOperator(DashboardFilter filter) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang3.StringUtils;
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.OperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterField;
 import com.axonivy.portal.util.filter.field.FilterFieldFactory;
 import com.axonivy.portal.util.filter.field.caze.CaseFilterFieldCreator;
@@ -27,6 +29,7 @@ import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
 import ch.ivy.addon.portalkit.dto.dashboard.casecolumn.CaseColumnModel;
 import ch.ivy.addon.portalkit.enums.DashboardColumnType;
 import ch.ivy.addon.portalkit.service.GlobalSettingService;
+import ch.ivy.addon.portalkit.service.WidgetFilterService;
 import ch.ivy.addon.portalkit.util.SecurityMemberUtils;
 
 public abstract class AbstractCaseWidgetFilterBean implements Serializable {
@@ -36,6 +39,7 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
   protected CaseDashboardWidget widget;
   protected List<FilterField> filterFields;
   protected Map<String, CaseColumnModel> mapHeaders;
+  private OperatorPolicyService operatorPolicyService;
 
   public void preRender(CaseDashboardWidget widget) {
     this.widget = widget;
@@ -43,11 +47,13 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
     this.mapHeaders = widget.getColumns().stream().collect(Collectors.toMap(CaseColumnModel::getField, Function.identity()));
     initFilterFields();
     initFilters();
+    this.operatorPolicyService = new OperatorPolicyService(this.widget.getFilterableColumns());
   }
 
   private void initFilterFields() {
-    Set<String> enabledFilterFieldNames = this.widget.getFilterableColumns().stream()
-      .map(ColumnModel::getField).collect(Collectors.toSet());
+    List<ColumnModel> effectiveColumns = WidgetFilterService.getEnabledFilterableColumns(this.widget);
+    Set<String> enabledFilterFieldNames = effectiveColumns.stream()
+        .map(ColumnModel::getField).collect(Collectors.toSet());
 
     this.filterFields = new ArrayList<>();
     this.filterFields.add(FilterFieldFactory.getDefaultFilterField());
@@ -62,7 +68,7 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
 
     updateFilterLabels();
     // Add custom fields which are selected by user.
-    this.widget.getFilterableColumns().stream().filter(col -> col.getType() == DashboardColumnType.CUSTOM)
+    effectiveColumns.stream().filter(col -> col.getType() == DashboardColumnType.CUSTOM)
         .map(col -> FilterFieldFactory.findCustomFieldBy(col.getField())).filter(Objects::nonNull)
         .forEach(this.filterFields::add);
 
@@ -112,6 +118,13 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
     return filterFields;
   }
 
+  public List<FilterOperator> resolveEffectiveOperatorsByPolicy(DashboardFilter filter) {
+    if (widget == null) {
+      return List.of();
+    }
+    return operatorPolicyService.resolveEffectiveOperators(filter);
+  }
+
   public void onSelectFilter(DashboardFilter filter) {
     String field = Optional.ofNullable(filter).map(DashboardFilter::getFilterField).map(FilterField::getName)
         .orElse(StringUtils.EMPTY);
@@ -124,6 +137,8 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
 
     filter.setLabel(filterField.getLabel());
     filterField.addNewFilter(filter);
+    // Override the operator with the first enabled operator according to the global and widget policy if the default one is not allowed
+    filter.setOperator(operatorPolicyService.findFirstEnabledOp(filter, filter.getOperator()).get());
     initCustomFieldNumberPattern(filter, field, filterField);
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
@@ -138,7 +138,7 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
     filter.setLabel(filterField.getLabel());
     filterField.addNewFilter(filter);
     // Override the operator with the first enabled operator according to the global and widget policy if the default one is not allowed
-    filter.setOperator(operatorPolicyService.findFirstEnabledOp(filter, filter.getOperator()).get());
+    operatorPolicyService.findFirstEnabledOp(filter, filter.getOperator()).ifPresent(filter::setOperator);
     initCustomFieldNumberPattern(filter, field, filterField);
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
@@ -136,7 +136,7 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
     filter.setLabel(filterField.getLabel());
     filter.getFilterField().addNewFilter(filter);
     // Override the operator with the first enabled operator according to the global and widget policy if the default one is not allowed
-    filter.setOperator(operatorPolicyService.findFirstEnabledOp(filter, filter.getOperator()).get());
+    operatorPolicyService.findFirstEnabledOp(filter, filter.getOperator()).ifPresent(filter::setOperator);
     initCustomFieldNumberPattern(filter, field, filter.getFilterField());
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang3.StringUtils;
 import com.axonivy.portal.components.dto.SecurityMemberDTO;
 import com.axonivy.portal.dto.dashboard.filter.BaseFilter;
 import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
+import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
+import com.axonivy.portal.service.filter.operatorpolicy.service.OperatorPolicyService;
 import com.axonivy.portal.util.filter.field.FilterField;
 import com.axonivy.portal.util.filter.field.TaskFilterFieldFactory;
 import com.axonivy.portal.util.filter.field.task.custom.TaskFilterFieldCustomNumber;
@@ -28,6 +30,7 @@ import ch.ivy.addon.portalkit.dto.dashboard.TaskDashboardWidget;
 import ch.ivy.addon.portalkit.dto.dashboard.taskcolumn.TaskColumnModel;
 import ch.ivy.addon.portalkit.enums.DashboardColumnType;
 import ch.ivy.addon.portalkit.enums.DashboardWidgetType;
+import ch.ivy.addon.portalkit.service.WidgetFilterService;
 import ch.ivy.addon.portalkit.util.SecurityMemberUtils;
 
 public abstract class AbstractTaskWidgetFilterBean implements Serializable {
@@ -37,17 +40,19 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
   protected TaskDashboardWidget widget;
   protected List<FilterField> filterFields;
   protected Map<String, TaskColumnModel> mapHeaders;
-
+  private OperatorPolicyService operatorPolicyService;
   public void preRender(TaskDashboardWidget widget) {
     this.widget = widget;
     this.widget.setInConfiguration(true);
     this.mapHeaders = widget.getColumns().stream().filter(item -> item.getType().equals(DashboardColumnType.STANDARD)).collect(Collectors.toMap(TaskColumnModel::getField, Function.identity()));
     initFilterFields();
     initFilters();
+    this.operatorPolicyService = new OperatorPolicyService(this.widget.getFilterableColumns());
   }
 
   private void initFilterFields() {
-    Set<String> enabledFilterFieldNames = this.widget.getFilterableColumns().stream()
+    List<ColumnModel> effectiveColumns = WidgetFilterService.getEnabledFilterableColumns(this.widget);
+    Set<String> enabledFilterFieldNames = effectiveColumns.stream()
       .map(ColumnModel::getField)
       .collect(Collectors.toSet());
 
@@ -59,7 +64,7 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
 
     updateFilterLabels();
     // Add custom fields which are selected by user.
-    this.widget.getFilterableColumns().stream().filter(column -> column.getType() != DashboardColumnType.STANDARD)
+    effectiveColumns.stream().filter(column -> column.getType() != DashboardColumnType.STANDARD)
         .map(column -> TaskFilterFieldFactory.findBy(this.widget.getId(),column.getField(), column.getType()))
         .filter(Objects::nonNull)
         .forEach(this.filterFields::add);
@@ -110,6 +115,13 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
     return filterFields;
   }
 
+  public List<FilterOperator> resolveEffectiveOperatorsByPolicy(DashboardFilter filter) {
+    if (widget == null) {
+      return List.of();
+    }
+    return operatorPolicyService.resolveEffectiveOperators(filter);
+  }
+
   public void onSelectFilter(DashboardFilter filter) {
     String field = Optional.ofNullable(filter).map(DashboardFilter::getFilterField).map(FilterField::getName)
         .orElse(StringUtils.EMPTY);
@@ -123,6 +135,8 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
     }
     filter.setLabel(filterField.getLabel());
     filter.getFilterField().addNewFilter(filter);
+    // Override the operator with the first enabled operator according to the global and widget policy if the default one is not allowed
+    filter.setOperator(operatorPolicyService.findFirstEnabledOp(filter, filter.getOperator()).get());
     initCustomFieldNumberPattern(filter, field, filter.getFilterField());
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/TaskWidgetUserFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/TaskWidgetUserFilterBean.java
@@ -39,7 +39,7 @@ public class TaskWidgetUserFilterBean extends AbstractTaskWidgetFilterBean {
     }
 
     // Remove user filters which are not in filterable columns anymore
-    WidgetFilterService.removeDisabledFilters(this.widget);
+    WidgetFilterService.pruneInvalidUserFilters(this.widget);
 
     for (DashboardFilter filter : this.widget.getUserFilters()) {
       if (Optional.ofNullable(filter).map(DashboardFilter::getFilterType)

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ColumnManagement/ColumnManagement.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ColumnManagement/ColumnManagement.xhtml
@@ -10,13 +10,15 @@
 <cc:implementation>
   <f:event listener="#{columnManagementBean.preRender(cc.attrs.widget)}" type="preRenderComponent" />
   <p:dialog id="column-management-dialog" widgetVar="column-management-dialog" header="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/columnManagement')}"
-    appendTo="@(body)" fitViewport="true" width="750" closeOnEscape="true" draggable="false" dynamic="true"
+    appendTo="@(body)" fitViewport="true" width="870" closeOnEscape="true" draggable="false" dynamic="true"
     responsive="true" modal="true" styleClass="dialog-responsive">
     <h:form id="column-management-form">
+      <p:remoteCommand name="updateColumnTable" update="column-management-datatable" global="false" />
       <ui:include src="FieldAdd.xhtml" />
 
       <p:dataTable id="column-management-datatable" value="#{columnManagementBean.columnsBeforeSave}" var="column"
-        draggableRows="true" rowDragSelector="i.ti-arrows-vertical" lazy="false">
+        draggableRows="true" rowDragSelector="i.ti-arrows-vertical" lazy="false"
+        styleClass="column-management-datatable">
         <p:ajax event="rowReorder" global="false" />
         <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/visible')}" width="70" styleClass="text-center">
           <p:commandLink id="toggle-visibility" styleClass="ui-selectbooleancheckbox ui-chkbox ui-widget #{columnManagementBean.isEnableHideCaseCreator(column) ? 'ui-disable' : ''}" process="@this"
@@ -37,6 +39,7 @@
           headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/filterLabel')}" width="50" styleClass="text-center">
           <p:commandLink id="toggle-filter" styleClass="ui-selectbooleancheckbox ui-chkbox ui-widget" process="@this"
             rendered="#{column.canFilter()}"
+            disabled="#{columnManagementBean.isFilterToggleDisabled(column)}"
             ariaLabel="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/filterLabel')}"
             actionListener="#{columnManagementBean.handleFilter(column)}"
             global="false" update="column-management-datatable" partialSubmit="true" immediate="true">
@@ -44,6 +47,33 @@
               <span class="ui-chkbox-icon ui-icon ui-c #{column.enableFilter ? 'ui-icon-check':'ui-icon-blank'}"></span>
             </h:panelGroup>
           </p:commandLink>
+        </p:column>
+        <p:column width="120" styleClass="text-center">
+          <f:facet name="header">
+            <h:panelGroup styleClass="column-management-operator-header inline-flex align-items-center">
+              <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/operators')}" />
+              <h:outputText id="operator-policy-info-icon" styleClass="ti ti-info-circle column-management-operator-info-icon" />
+            </h:panelGroup>
+            <p:tooltip for="operator-policy-info-icon"
+              value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/operatorPolicyTooltip')}"
+              hideEvent="mouseleave click" />
+          </f:facet>
+          <h:panelGroup rendered="#{column.canFilter()}">
+            <p:selectCheckboxMenu id="operator-selection" value="#{column.allowedOperators}" multiple="false" filter="false"
+              updateLabel="false" disabled="#{not column.enableFilter}"
+              panelStyleClass="task-configuration__selectcheckboxmenu-panel task-configuration__operator-selection-panel"
+              styleClass="task-configuration__selectcheckboxmenu task-configuration__operator-selection-menu js-operator-selection-#{column.field}"
+              label="#{columnManagementBean.operatorCountingLabel(column)}"
+              onHide="updateColumnTable()">
+              <f:selectItems value="#{columnManagementBean.getAvailableOperators(column)}" var="operator"
+                itemValue="#{operator}" itemLabel="#{operator.label}"
+                itemDisabled="#{not columnManagementBean.isOperatorGloballyEnabled(operator)}" />
+              <p:ajax event="change" listener="#{columnManagementBean.onOperatorSelectionChange(column)}"
+                process="@this" global="false" />
+              <p:ajax event="toggleSelect" listener="#{columnManagementBean.onOperatorSelectionChange(column)}"
+                process="@this" global="false" />
+            </p:selectCheckboxMenu>
+          </h:panelGroup>
         </p:column>
         <p:column headerText="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/QuickSearch')}" width="90" styleClass="text-center">
           <h:panelGroup layout="block" id="quick-search-checkbox-panel"

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/ApplicationFilter/ApplicationFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/ApplicationFilter/ApplicationFilter.xhtml
@@ -11,6 +11,7 @@
   <cc:attribute name="filterIndex" />
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -25,7 +26,7 @@
     styleClass="ui-fluid application-filter-operator-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{widgetApplicationFilterBean.operators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetTextFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate}" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/CategoryFilter/CategoryFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/CategoryFilter/CategoryFilter.xhtml
@@ -12,7 +12,7 @@
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
   <cc:attribute name="widgetType" required="true"/>
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -27,7 +27,7 @@
     styleClass="ui-fluid category-filter-operation-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{cc.attrs.operators ne null ? cc.attrs.operators : widgetCategoryFilterBean.operators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetCategoryFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate} category-list-panel" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/CreatedDateFilter/CreatedDateFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/CreatedDateFilter/CreatedDateFilter.xhtml
@@ -10,7 +10,7 @@
   <cc:attribute name="filterIndex" />
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
   <cc:attribute name="widgetType" required="true"/>
   
 </cc:interface>
@@ -19,7 +19,7 @@
   <ic:com.axonivy.portal.dashboard.component.filter.DateFilter componentToUpdate="#{cc.attrs.componentToUpdate}"
     widgetType="#{cc.attrs.widgetType}"
     filter="#{cc.attrs.filter}" filterIndex="#{cc.attrs.filterIndex}" messageId="#{cc.attrs.messageId}"
-    readOnly="#{cc.attrs.readOnly}" operators="#{widgetDateFilterBean.createdDateOperators}" />
+    readOnly="#{cc.attrs.readOnly}" operators="#{cc.attrs.operators}" />
 </cc:implementation>
 
 </html>

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/CreatorFilter/CreatorFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/CreatorFilter/CreatorFilter.xhtml
@@ -12,7 +12,7 @@
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
   <cc:attribute name="creatorCompleteMethod" required="true" method-signature="java.util.List creatorCompleteMethod(java.lang.String)" />
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -28,7 +28,7 @@
     styleClass="ui-fluid creator-filter-operation-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{operators ne null ? operators : widgetCreatorFilterBean.operators}" var="operator"
+        <f:selectItems value="#{operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetCreatorFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate} creator-list-panel" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/DashboardFilter/DashboardFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/DashboardFilter/DashboardFilter.xhtml
@@ -19,6 +19,7 @@
   <c:set var="widget" value="#{cc.attrs.widget}" />
   <c:set var="filter" value="#{cc.attrs.filter}" />
   <c:set var="readOnly" value="#{cc.attrs.readOnly}" />
+  <c:set var="effectiveOperators" value="#{cc.attrs.managedBean.resolveEffectiveOperatorsByPolicy(filter)}" />
 
   <div class="ui-g-12 dashboard-widget-filter__filter-wrapper">
     <h:panelGroup id="filter-selection-panel" layout="block" styleClass="dashboard-widget-filter__filter-panel filter-selection-panel">
@@ -39,31 +40,32 @@
       <h:panelGroup layout="block" rendered="#{filter.isCustomDateField() or filter.isFinishedDateField() or filter.isExpiryDateField()}">
         <ic:com.axonivy.portal.dashboard.component.filter.DateFilter filter="#{filter}" widgetType="#{widget.getType()}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}"/>
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}"/>
       </h:panelGroup>
   
       <h:panelGroup layout="block" rendered="#{filter.isCreatedDateField()}">
         <ic:com.axonivy.portal.dashboard.component.filter.CreatedDateFilter filter="#{filter}" widgetType="#{widget.getType()}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}"/>
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}"/>
       </h:panelGroup>
   
       <h:panelGroup layout="block" rendered="#{filter.isTextField()}">
         <ic:com.axonivy.portal.dashboard.component.filter.TextFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
   
       <h:panelGroup layout="block" rendered="#{filter.isNumberField()}">
         <ic:com.axonivy.portal.dashboard.component.filter.NumberFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
   
       <h:panelGroup layout="block" rendered="#{filter.isCreator()}">
         <ic:com.axonivy.portal.dashboard.component.filter.CreatorFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
           readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}"
+          operators="#{effectiveOperators}"
           creatorCompleteMethod="#{cc.attrs.managedBean.completeCreators}" />
       </h:panelGroup>
 
@@ -71,6 +73,7 @@
         <ic:com.axonivy.portal.dashboard.component.filter.ResponsibleFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
           readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}"
+          operators="#{effectiveOperators}"
           responsibleCompleteMethod="#{cc.attrs.managedBean.completeOwners}" />
       </h:panelGroup>
       
@@ -78,6 +81,7 @@
         <ic:com.axonivy.portal.dashboard.component.filter.WorkerFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
           readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}"
+          operators="#{effectiveOperators}"
           workerCompleteMethod="#{cc.attrs.managedBean.completeUsers}" />
       </h:panelGroup>
 
@@ -86,45 +90,45 @@
           filter="#{filter}" widgetType="#{widget.getType()}"
           componentToUpdate="#{cc.attrs.componentToUpdate}"
           filterIndex="#{cc.attrs.filterIndex}" readOnly="#{readOnly}"
-          messageId="#{cc.attrs.messageId}" />
+          messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
   
       <h:panelGroup layout="block" rendered="#{filter.isApplication()}">
         <ic:com.axonivy.portal.dashboard.component.filter.ApplicationFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
   
       <h:panelGroup layout="block" rendered="#{filter.isState()}">
         <ic:com.axonivy.portal.dashboard.component.filter.StateFilter filter="#{filter}"
           widgetType="#{widget.getType()}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
 
       <h:panelGroup layout="block" rendered="#{filter.isPriority()}">
         <ic:com.axonivy.portal.dashboard.component.filter.PriorityFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
       
   
       <h:panelGroup layout="block" rendered="#{filter.isId()}">
         <ic:com.axonivy.portal.dashboard.component.filter.IdFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
 
       <h:panelGroup layout="block" rendered="#{filter.isBusinessCaseId()}">
         <ic:com.axonivy.portal.dashboard.component.filter.IdFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
 
       <h:panelGroup layout="block" rendered="#{filter.isTechnicalCaseId()}">
         <ic:com.axonivy.portal.dashboard.component.filter.IdFilter filter="#{filter}"
           componentToUpdate="#{cc.attrs.componentToUpdate}" filterIndex="#{cc.attrs.filterIndex}"
-          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" />
+          readOnly="#{readOnly}" messageId="#{cc.attrs.messageId}" operators="#{effectiveOperators}" />
       </h:panelGroup>
   
       <div class="remove-filter-panel">

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/DateFilter/DateFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/DateFilter/DateFilter.xhtml
@@ -12,7 +12,7 @@
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
   <cc:attribute name="widgetType" required="true"/>
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -27,7 +27,7 @@
     styleClass="ui-fluid">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{operators ne null ? operators : widgetDateFilterBean.operators}" var="operator"
+        <f:selectItems value="#{operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetDateFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate}" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/IdFilter/IdFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/IdFilter/IdFilter.xhtml
@@ -11,6 +11,7 @@
   <cc:attribute name="filterIndex" />
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -23,7 +24,7 @@
     styleClass="ui-fluid id-filter-operator-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{widgetIdFilterBean.operators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetIdFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate}" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/NumberFilter/NumberFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/NumberFilter/NumberFilter.xhtml
@@ -11,7 +11,7 @@
   <cc:attribute name="filterIndex" />
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -24,7 +24,7 @@
     styleClass="ui-fluid">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{cc.attrs.operators ne null ? cc.attrs.operators : widgetNumberFilterBean.operators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetNumberFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate}" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/PriorityFilter/PriorityFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/PriorityFilter/PriorityFilter.xhtml
@@ -11,7 +11,7 @@
   <cc:attribute name="filterIndex" />
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -26,7 +26,7 @@
     styleClass="ui-fluid priority-filter-operator-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{cc.attrs.operators ne null ? cc.attrs.operators : widgetPriorityFilterBean.priorityOperators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
       </p:selectOneMenu>
   </h:panelGroup>

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/ResponsibleFilter/ResponsibleFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/ResponsibleFilter/ResponsibleFilter.xhtml
@@ -12,7 +12,7 @@
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
   <cc:attribute name="responsibleCompleteMethod" required="true" method-signature="java.util.List responsibleCompleteMethod(java.lang.String)"/>
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -27,7 +27,7 @@
   <h:panelGroup id="responsible-filter-operator-panel" layout="block"
     styleClass="ui-fluid responsible-filter-operator-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}" pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{operators ne null ? operators : widgetResponsibleFilterBean.operators}" var="operator"
+        <f:selectItems value="#{operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetResponsibleFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate} responsible-list-panel" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/StateFilter/StateFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/StateFilter/StateFilter.xhtml
@@ -12,7 +12,7 @@
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
   <cc:attribute name="widgetType" required="true"/>
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -28,7 +28,7 @@
     styleClass="ui-fluid state-filter-operator-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{cc.attrs.operators ne null ? cc.attrs.operators : widgetStateFilterBean.stateOperators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
       </p:selectOneMenu>
   </h:panelGroup>

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/TextFilter/TextFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/TextFilter/TextFilter.xhtml
@@ -11,7 +11,7 @@
   <cc:attribute name="filterIndex" />
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
-  <cc:attribute name="operators" />
+  <cc:attribute name="operators" required="true" />
 </cc:interface>
 
 <cc:implementation>
@@ -24,7 +24,7 @@
     styleClass="ui-fluid">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}"
         pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{cc.attrs.operators ne null ? cc.attrs.operators : widgetTextFilterBean.isCustomFieldWithCms(filter) ? widgetTextFilterBean.operatorsForCustomFieldWithCms : widgetTextFilterBean.operators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}"/>
           <p:ajax event="itemSelect" listener="#{widgetTextFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate}" partialSubmit="true" global="false" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/WorkerFilter/WorkerFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/filter/WorkerFilter/WorkerFilter.xhtml
@@ -11,6 +11,7 @@
   <cc:attribute name="filterIndex" />
   <cc:attribute name="readOnly" default="false" />
   <cc:attribute name="messageId" />
+  <cc:attribute name="operators" required="true" />
   <cc:attribute name="workerCompleteMethod" required="true" method-signature="java.util.List workerCompleteMethod(java.lang.String)"/>
 </cc:interface>
 
@@ -25,7 +26,7 @@
   <h:panelGroup id="worker-filter-operator-panel" layout="block"
     styleClass="ui-fluid md-inputfield worker-filter-operator-panel">
       <p:selectOneMenu id="operator-selection" value="#{filter.operator}" disabled="#{readOnly}" pt:aria-label="#{ivy.cms.co('/Labels/SelectOperator')}">
-        <f:selectItems value="#{widgetWorkerFilterBean.operators}" var="operator"
+        <f:selectItems value="#{cc.attrs.operators}" var="operator"
           itemValue="#{operator}" itemLabel="#{operator.label}" />
           <p:ajax event="itemSelect" listener="#{widgetWorkerFilterBean.onChangeOperator(filter)}"
             update="#{cc.attrs.componentToUpdate} worker-list-panel" />

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/TableWidget.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/TableWidget.xhtml
@@ -308,7 +308,13 @@
   
             <h:panelGroup id="widget-filter-content" styleClass="ui-g-9 u-padding-0 ui-sm-12 flex flex-column" layout="block">
               <div class="ui-g-12 filter-overlay-panel__header pt-3 flex ">
-                <strong class="ui-g-12">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterOptionHeader')}</strong>
+                <div class="ui-g-12 flex align-items-center gap-1">
+                  <strong>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterOptionHeader')}</strong>
+                  <h:outputText id="filter-option-header-info-#{index}" styleClass="ti ti-info-circle" />
+                  <p:tooltip for="filter-option-header-info-#{index}"
+                      value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterOptionHeaderTooltip')}"
+                      position="bottom" />
+                </div>
                 <p:commandButton icon="ti ti-x" id="widget-filter-cancel-button"
                     ariaLabel="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/closeContext', [ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/Filter/FilterPanelHeader')])}"
                     styleClass="ui-overlaypanel-footer__cancel flex align-items-center ui-button-flat rounded-button text-2xl"

--- a/AxonIvyPortal/portal/webContent/resources/css/dashboard.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/dashboard.css
@@ -479,12 +479,25 @@ body .ui-selectcheckboxmenu.task-configuration__selectcheckboxmenu {
   background-image: none;
 }
 
+body .ui-selectcheckboxmenu.task-configuration__selectcheckboxmenu.task-configuration__operator-selection-menu {
+  float: none;
+  width: 65%;
+}
+
 body .ui-selectcheckboxmenu.task-configuration__selectcheckboxmenu .ui-selectcheckboxmenu-trigger .ui-icon {
   top: 5px;
 }
 
 .task-configuration__selectcheckboxmenu-panel {
   width: 300px;
+}
+
+.task-configuration__operator-selection-panel {
+  width: 220px;
+}
+
+.task-configuration__operator-selection-panel .ui-selectcheckboxmenu-item:has(.ui-chkbox-box.ui-state-disabled) > label {
+  color: var(--action-step-disabled-text-color);
 }
 
 .task-configuration__column-picker.ui-picklist .ui-picklist-list {
@@ -786,6 +799,20 @@ body .dashboard__table--preview.ui-datatable tbody tr.ui-state-hover {
 .column-management-datatable__reorder i {
   cursor: move;
   padding: 4px 10px;
+}
+
+.column-management-operator-header {
+  gap: 0.35rem;
+}
+
+.column-management-operator-info-icon {
+  color: var(--ivy-primary-color-grey-medium);
+  cursor: pointer;
+}
+
+.column-management-datatable.ui-datatable tbody.ui-datatable-data > tr > td {
+  height: 50px;
+  vertical-align: middle;
 }
 
 .dashboard-tasks__id,

--- a/AxonIvyPortal/portal/webContent/resources/css/module.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/module.css
@@ -3704,6 +3704,13 @@ _:-ms-input-placeholder, :root .icon-selection-dialog-selecting-icon .fa {
   right: 1rem;
 }
 
+.admin-settings-container .ui-selectcheckboxmenu .ui-selectcheckboxmenu-label {
+  max-width: calc(100% - 2rem);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .application-input-with-button {
   margin-top: 3px !important;
 }


### PR DESCRIPTION
- Add Operators column to `ColumnManagement.xhtml` with a `p:selectCheckboxMenu` showing available operators per field
- Globally disabled operators are shown as greyed-out and cannot be selected; filter toggle is disabled when all operators for a field are globally disabled
- Predefined and user filters using disallowed operators are automatically pruned.
- #3451 