### PR TITLE
IVYPORTAL-20522 Fix not auto remove predefined filter and missing case creator standard col

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portal/generic/bean/ColumnManagementBean.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -25,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 
 import com.axonivy.portal.components.util.FacesMessageUtils;
-import com.axonivy.portal.dto.dashboard.filter.DashboardFilter;
 import com.axonivy.portal.service.DeepLTranslationService;
 
 import ch.ivy.addon.portalkit.dto.DisplayName;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractCaseWidgetFilterBean.java
@@ -79,6 +79,8 @@ public abstract class AbstractCaseWidgetFilterBean implements Serializable {
       return;
     }
 
+    this.widget.setFilters(GlobalOperatorPolicyService.getInstance().keepGloballyEnabledFilters(this.widget.getFilters()));
+
     // If the filter available in the filter list, initialize it
     for (DashboardFilter filter : this.widget.getFilters()) {
       if (isFilterAvailable(filter)) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/bean/dashboard/filter/AbstractTaskWidgetFilterBean.java
@@ -75,6 +75,8 @@ public abstract class AbstractTaskWidgetFilterBean implements Serializable {
       return;
     }
 
+    this.widget.setFilters(GlobalOperatorPolicyService.getInstance().keepGloballyEnabledFilters(this.widget.getFilters()));
+
     // If the filter available in the filter list, initialize it
     for (DashboardFilter filter : this.widget.getFilters()) {
       if (isFilterAvailable(filter)) {

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/BaselineOperatorService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/filter/operatorpolicy/BaselineOperatorService.java
@@ -13,6 +13,7 @@ import com.axonivy.portal.enums.dashboard.filter.FilterOperator;
 
 import ch.ivy.addon.portalkit.dto.dashboard.ColumnModel;
 import ch.ivy.addon.portalkit.enums.DashboardColumnFormat;
+import ch.ivy.addon.portalkit.enums.DashboardStandardCaseColumn;
 import ch.ivy.addon.portalkit.enums.DashboardStandardTaskColumn;
 
 public class BaselineOperatorService {
@@ -35,6 +36,7 @@ public class BaselineOperatorService {
     map.put(DashboardStandardTaskColumn.NAME.getField(), FilterOperator.TEXT_OPERATORS);
     map.put(DashboardStandardTaskColumn.DESCRIPTION.getField(), FilterOperator.TEXT_OPERATORS);
     map.put(DashboardStandardTaskColumn.EXPIRY.getField(), FilterOperator.DATE_OPERATORS);
+    map.put(DashboardStandardCaseColumn.CREATOR.getField(), FilterOperator.CREATOR_OPERATORS);
     FIELD_OPERATORS_MAP = Collections.unmodifiableMap(map);
   }
 


### PR DESCRIPTION
Bug predefined filter is broken if its op is disabled:
<img width="1830" height="479" alt="image" src="https://github.com/user-attachments/assets/1ef22072-3a8a-48f7-86dd-c471f9621472" />

Missing case creator standard field in new base operator file leads to failed build: https://github.com/axonivy-market/portal/actions/runs/28140103919#user-content-tr-HwvJw-r4, https://github.com/axonivy-market/portal/actions/runs/28126513870

I'm running again at: https://github.com/axonivy-market/portal/actions/runs/28160576530, https://github.com/axonivy-market/portal/actions/runs/28160535340
