### PR TITLE
IVYPORTAL-20448 Safe reduce js warnings for all projects

### DIFF
--- a/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/OneComponent.xhtml
+++ b/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/OneComponent.xhtml
@@ -17,7 +17,7 @@
   <h:outputScript name="js/perfect-scrollbar.js" library="modena-layout" />
   <h:outputScript name="js/layout.js" library="modena-layout" />
 
-  <script src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
+  <script type="text/javascript" src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
   <ui:insert name="head" />
 </h:head>
 

--- a/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/basic.xhtml
+++ b/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/basic.xhtml
@@ -21,7 +21,7 @@
 	<h:outputScript name="js/perfect-scrollbar.js" library="modena-layout" />
 	<h:outputScript name="js/layout.js" library="modena-layout" />
 
-	<script>
+	<script type="text/javascript">
 		$(document).ready(function() {
 			// define global event for Firefox		
 			if (typeof event == 'undefined') {

--- a/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/frame-10.xhtml
+++ b/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/frame-10.xhtml
@@ -51,7 +51,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->

--- a/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/processChain.xhtml
+++ b/AxonIvyPortal/PortalKitTestHelper/webContent/layouts/processChain.xhtml
@@ -17,7 +17,7 @@
   <h:outputStylesheet name="layouts/styles/style.css" />
   <h:outputStylesheet library="ivy-webcontent" name="custom-style.css" />
   <h:outputStylesheet library="ivy-webcontent" name="styles/custom-style.css" />
-<script>
+<script type="text/javascript">
 		$(document).ready(function() {	
 			// define global event for Firefox		
 			if (typeof event == 'undefined'){

--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/IFrameTaskConfig/IFrameTaskConfig.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/IFrameTaskConfig/IFrameTaskConfig.xhtml
@@ -3,11 +3,11 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions">
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="taskName" shortDescription="Custom text for task name" />
-  <cc:attribute name="taskIcon" shortDescription="Task icon to be displayed, using Tabler or Awesome font, e.g., 'ti ti-arrow-right'" />
-  <cc:attribute name="isHideTaskName" shortDescription="Hide task name, false (default) or true" />
-  <cc:attribute name="caseId" shortDescription="ID of case to be displayed in case information dialog" />
-  <cc:attribute name="isHideCaseInfo" shortDescription="Hide `Show Information` button, false (default) or true" />
+  <cc:attribute name="taskName" type="java.lang.String" shortDescription="Custom text for task name" />
+  <cc:attribute name="taskIcon" type="java.lang.String" shortDescription="Task icon to be displayed, using Tabler or Awesome font, e.g., 'ti ti-arrow-right'" />
+  <cc:attribute name="isHideTaskName" type="java.lang.Boolean" shortDescription="Hide task name, false (default) or true" />
+  <cc:attribute name="caseId" type="java.lang.String" shortDescription="ID of case to be displayed in case information dialog" />
+  <cc:attribute name="isHideCaseInfo" type="java.lang.Boolean" shortDescription="Hide `Show Information` button, false (default) or true" />
   <cc:attribute name="currentProcessStep" shortDescription="Current process step, could be the index of the step or the step name" />
   <cc:attribute name="processSteps" shortDescription="List of process steps, e.g., `[&quot;Create Investment Request&quot;, &quot;Approve Investment Reques&quot;]`
     or `# {portalComponentUtilsBean.convertToJSON(data.steps)}`" />
@@ -23,46 +23,46 @@
 </cc:interface> 
 
 <cc:implementation>
-  <ui:fragment rendered="#{not empty cc.attrs.taskName}"><script>window.taskName = '#{htmlSanitizerBean.escapeForJS(cc.attrs.taskName)}';</script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.taskIcon}"><script>window.taskIcon = '#{htmlSanitizerBean.escapeForIcon(cc.attrs.taskIcon)}';</script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.isHideTaskName}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.taskName}"><script type="text/javascript">window.taskName = '#{htmlSanitizerBean.escapeForJS(cc.attrs.taskName)}';</script></ui:fragment>
+  <ui:fragment rendered="#{not empty cc.attrs.taskIcon}"><script type="text/javascript">window.taskIcon = '#{htmlSanitizerBean.escapeForIcon(cc.attrs.taskIcon)}';</script></ui:fragment>
+  <ui:fragment rendered="#{cc.attrs.isHideTaskName}"><script type="text/javascript">
     window.isHideTaskName = ('#{htmlSanitizerBean.escapeForJS(cc.attrs.isHideTaskName)}'.toLowerCase() === "true");
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.caseId}"><script>window.caseId = '#{htmlSanitizerBean.escapeForJS(cc.attrs.caseId)}';</script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.isHideCaseInfo}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.caseId}"><script type="text/javascript">window.caseId = '#{htmlSanitizerBean.escapeForJS(cc.attrs.caseId)}';</script></ui:fragment>
+  <ui:fragment rendered="#{cc.attrs.isHideCaseInfo}"><script type="text/javascript">
     window.isHideCaseInfo = ('#{htmlSanitizerBean.escapeForJS(cc.attrs.isHideCaseInfo)}'.toLowerCase() === "true");
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.currentProcessStep}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.currentProcessStep}"><script type="text/javascript">
     window.currentProcessStep = '#{htmlSanitizerBean.escapeForJS(cc.attrs.currentProcessStep)}';
     if (!isNaN(Number(window.currentProcessStep))) {
       window.currentProcessStep = Number(window.currentProcessStep);
     }
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.processSteps}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.processSteps}"><script type="text/javascript">
     try {
       window.processSteps = JSON.parse('#{htmlSanitizerBean.escapeForJS(cc.attrs.processSteps)}');
     } catch (error) {
       // Just ignore parsing JSON processSteps
     }
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.isShowAllSteps}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.isShowAllSteps}"><script type="text/javascript">
     window.isShowAllSteps = ('#{htmlSanitizerBean.escapeForJS(cc.attrs.isShowAllSteps)}'.toLowerCase() === "true");
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.processChainDirection}"><script>window.processChainDirection = '#{htmlSanitizerBean.escapeForJS(cc.attrs.processChainDirection)}';</script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.processChainShape}"><script>window.processChainShape = '#{htmlSanitizerBean.escapeForJS(cc.attrs.processChainShape)}';</script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.isHideTaskAction}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.processChainDirection}"><script type="text/javascript">window.processChainDirection = '#{htmlSanitizerBean.escapeForJS(cc.attrs.processChainDirection)}';</script></ui:fragment>
+  <ui:fragment rendered="#{not empty cc.attrs.processChainShape}"><script type="text/javascript">window.processChainShape = '#{htmlSanitizerBean.escapeForJS(cc.attrs.processChainShape)}';</script></ui:fragment>
+  <ui:fragment rendered="#{not empty cc.attrs.isHideTaskAction}"><script type="text/javascript">
     window.isHideTaskAction = ('#{htmlSanitizerBean.escapeForJS(cc.attrs.isHideTaskAction)}'.toLowerCase() === "true");
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.isWorkingOnATask}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.isWorkingOnATask}"><script type="text/javascript">
     window.isWorkingOnATask = ('#{htmlSanitizerBean.escapeForJS(cc.attrs.isWorkingOnATask)}'.toLowerCase() === "true");
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.announcementInvisible}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.announcementInvisible}"><script type="text/javascript">
     window.announcementInvisible = ('#{htmlSanitizerBean.escapeForJS(cc.attrs.announcementInvisible)}'.toLowerCase() === "true");
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.isCardFrame}"><script>
+  <ui:fragment rendered="#{not empty cc.attrs.isCardFrame}"><script type="text/javascript">
     window.isCardFrame = ('#{htmlSanitizerBean.escapeForJS(cc.attrs.isCardFrame)}'.toLowerCase() === "true");
   </script></ui:fragment>
-  <ui:fragment rendered="#{not empty cc.attrs.viewName}"><script>window.viewName = '#{htmlSanitizerBean.escapeForJS(cc.attrs.viewName)}';</script></ui:fragment>
+  <ui:fragment rendered="#{not empty cc.attrs.viewName}"><script type="text/javascript">window.viewName = '#{htmlSanitizerBean.escapeForJS(cc.attrs.viewName)}';</script></ui:fragment>
 </cc:implementation>
 
 </html>

--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/RoleSelection/RoleSelection.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/RoleSelection/RoleSelection.xhtml
@@ -22,14 +22,14 @@
     shortDescription="When enabled, only roles from the suggestion list can be selected. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="minQueryLength" default="1"
     shortDescription="Minimum number of characters required to start searching. Type: int. Default value: 1. Required: false." />
-  <cc:attribute name="isDisabled" shortDescription="Disables the role selection input. Type: boolean. Default value: false. Required: false." />
-  <cc:attribute name="isRequired" shortDescription="Marks the role selection field as required. Type: boolean. Default value: false. Required: false." />
-  <cc:attribute name="isReadOnly" shortDescription="Prevents changing the selected role when enabled. Type: boolean. Default value: false. Required: false." />
+  <cc:attribute name="isDisabled" type="java.lang.Boolean" shortDescription="Disables the role selection input. Type: boolean. Default value: false. Required: false." />
+  <cc:attribute name="isRequired" type="java.lang.Boolean" shortDescription="Marks the role selection field as required. Type: boolean. Default value: false. Required: false." />
+  <cc:attribute name="isReadOnly" type="java.lang.Boolean" shortDescription="Prevents changing the selected role when enabled. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="hightlight" type="java.lang.Boolean" default="true" shortDescription="Automatically highlights the first suggested role. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="size" shortDescription="Number of characters used to define the input width. Type: int. Required: false." />
   <cc:attribute name="itemLabel" default="#{role.getDisplayName() != '' ? role.getDisplayName() : role.getMemberName()}"
     shortDescription="Text displayed for roles in the dropdown and the selected value. Type: String. Default value: #{role.getDisplayName() != '' ? role.getDisplayName() : role.getMemberName()}. Required: false." />
-  <cc:attribute name="scrollHeight" default="390" shortDescription="Maximum height of the autocomplete dropdown panel. Type: int. Default value: 390. Required: false." />
+  <cc:attribute name="scrollHeight" type="java.lang.Integer" default="390" shortDescription="Maximum height of the autocomplete dropdown panel. Type: int. Default value: 390. Required: false." />
   <cc:attribute name="inputStyleClass" shortDescription="CSS style class applied to the role autocomplete input field. Type: String. Required: false." />
   <cc:attribute name="autoCompleteStyleClass" shortDescription="CSS style class applied to the role autocomplete component. Type: String. Required: false." />
   <cc:attribute name="autoCompletePanelStyleClass" shortDescription="CSS style class applied to the role autocomplete dropdown panel. Type: String. Required: false." />
@@ -38,7 +38,7 @@
   <cc:attribute name="cache" type="java.lang.Boolean" default="true"
     shortDescription="Caches autocomplete search results when enabled. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="moreText" default="#{ivy.cms.co('/Dialogs/com/axonivy/portal/components/Common/More')}..." shortDescription="Text displayed for the 'More' link when results exceed the limit. Type: String. Default value: More.... Required: false." />
-  <cc:attribute name="queryDelay" default="300" shortDescription="Delay in milliseconds before sending the search query. Type: int. Default value: 300. Required: false." />
+  <cc:attribute name="queryDelay" type="java.lang.Integer" default="300" shortDescription="Delay in milliseconds before sending the search query. Type: int. Default value: 300. Required: false." />
   <cc:attribute name="maxResults" default="100" type="java.lang.Integer" shortDescription="Maximum number of results displayed in the dropdown. Type: int. Default value: 100. Required: false." />
   <cc:attribute name="hasCustomizedSelectionList" type="java.lang.Boolean" default="false" shortDescription="Displays a customized selection list when enabled. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="emptyMessage" shortDescription="Message displayed when no results are available. Type: String. Default value: No results. Required: false."
@@ -56,7 +56,7 @@
 
   <!-- Label attributes -->
   <cc:attribute name="label" shortDescription="Label text for the role selection component. Type: String. Required: false." />
-  <cc:attribute name="floatingLabel"
+  <cc:attribute name="floatingLabel" type="java.lang.Boolean"
     shortDescription="Displays the label using floating style. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="labelStyleClass" shortDescription="CSS style class applied to the label. Type: String. Required: false." />
   <cc:attribute name="appendOption" shortDescription="Additional information appended to the role display, such as parent role name or none. Value: NONE, PARENT_NAME. Type: String. Required: false." />

--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/RoleSelection/RoleSelection.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/RoleSelection/RoleSelection.xhtml
@@ -20,13 +20,13 @@
     shortDescription="Validation message displayed when the required field is empty. Type: String. Default value: 'This field is required'. Required: false." />
   <cc:attribute name="forceSelection" type="java.lang.Boolean" default="true"
     shortDescription="When enabled, only roles from the suggestion list can be selected. Type: boolean. Default value: true. Required: false." />
-  <cc:attribute name="minQueryLength" default="1"
+  <cc:attribute name="minQueryLength" type="java.lang.Integer" default="1"
     shortDescription="Minimum number of characters required to start searching. Type: int. Default value: 1. Required: false." />
   <cc:attribute name="isDisabled" type="java.lang.Boolean" shortDescription="Disables the role selection input. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="isRequired" type="java.lang.Boolean" shortDescription="Marks the role selection field as required. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="isReadOnly" type="java.lang.Boolean" shortDescription="Prevents changing the selected role when enabled. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="hightlight" type="java.lang.Boolean" default="true" shortDescription="Automatically highlights the first suggested role. Type: boolean. Default value: true. Required: false." />
-  <cc:attribute name="size" shortDescription="Number of characters used to define the input width. Type: int. Required: false." />
+  <cc:attribute name="size" type="java.lang.Integer" shortDescription="Number of characters used to define the input width. Type: int. Required: false." />
   <cc:attribute name="itemLabel" default="#{role.getDisplayName() != '' ? role.getDisplayName() : role.getMemberName()}"
     shortDescription="Text displayed for roles in the dropdown and the selected value. Type: String. Default value: #{role.getDisplayName() != '' ? role.getDisplayName() : role.getMemberName()}. Required: false." />
   <cc:attribute name="scrollHeight" type="java.lang.Integer" default="390" shortDescription="Maximum height of the autocomplete dropdown panel. Type: int. Default value: 390. Required: false." />
@@ -45,7 +45,7 @@
     default="#{ivy.cms.co('/Labels/NoResults')}" />
 
   <!-- Avatar in Selection list attributes  -->
-  <cc:attribute name="isShowAvatarInSelectionList" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
+  <cc:attribute name="isShowAvatarInSelectionList" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
     shortDescription="Displays role avatars in the selection list when enabled. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="displayNameRenderedInSelectionList" type="java.lang.Boolean" default="true"
     shortDescription="Controls visibility of the role display name in the selection list. Type: boolean. Default value: true. Required: false." />

--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/UserSelection/UserSelection.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/UserSelection/UserSelection.xhtml
@@ -16,15 +16,15 @@
   <cc:attribute name="requiredMessage" default="#{ivy.cms.co('/Dialogs/com/axonivy/portal/components/Common/RequiredFieldMessage')}" 
   	shortDescription="Validation message displayed when the required field is empty. Type: String. Default value: 'This field is required'. Required: false."/>
   <cc:attribute name="forceSelection" type="java.lang.Boolean" default="true" shortDescription="When enabled, only users from the suggestion list can be selected. Type: boolean. Default value: true. Required: false." />
-  <cc:attribute name="minQueryLength" default="1" shortDescription="Minimum number of characters required to start searching. Type: int. Default value: 1. Required: false." />
-  <cc:attribute name="isDisabled" shortDescription="Disables the user selection input. Type: boolean. Default value: false. Required: false." />
-  <cc:attribute name="isRequired" shortDescription="Marks the user selection field as required. Type: boolean. Default value: false. Required: false." />
-  <cc:attribute name="isReadOnly" shortDescription="Prevents changing the selected user when enabled. Type: boolean. Default value: false. Required: false." />
+  <cc:attribute name="minQueryLength" type="java.lang.Integer" default="1" shortDescription="Minimum number of characters required to start searching. Type: int. Default value: 1. Required: false." />
+  <cc:attribute name="isDisabled" type="java.lang.Boolean" shortDescription="Disables the user selection input. Type: boolean. Default value: false. Required: false." />
+  <cc:attribute name="isRequired" type="java.lang.Boolean" shortDescription="Marks the user selection field as required. Type: boolean. Default value: false. Required: false." />
+  <cc:attribute name="isReadOnly" type="java.lang.Boolean" shortDescription="Prevents changing the selected user when enabled. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="hightlight" type="java.lang.Boolean" default="true" shortDescription="Automatically highlights the first suggested user. Type: boolean. Default value: true. Required: false." />
-  <cc:attribute name="size" shortDescription="Number of characters used to define the input width. Type: int. Required: false." />
+  <cc:attribute name="size" type="java.lang.Integer" shortDescription="Number of characters used to define the input width. Type: int. Required: false." />
   <cc:attribute name="itemLabel" default="#{user.getDisplayName()}"
     shortDescription="Text displayed for users in the dropdown and the selected value. Type: String. Default value: user's display name. Required: false." />
-  <cc:attribute name="scrollHeight" default="390" shortDescription="Maximum height of the autocomplete dropdown panel. Type: int. Default value: 390. Required: false." />
+  <cc:attribute name="scrollHeight" type="java.lang.Integer" default="390" shortDescription="Maximum height of the autocomplete dropdown panel. Type: int. Default value: 390. Required: false." />
   <cc:attribute name="inputStyleClass" shortDescription="CSS style class applied to the autocomplete input field. Type: String. Required: false." />
   <cc:attribute name="autoCompleteStyleClass" shortDescription="CSS style class applied to the autocomplete component. Type: String. Required: false." />
   <cc:attribute name="autoCompletePanelStyleClass" shortDescription="CSS style class applied to the autocomplete dropdown panel. Type: String. Required: false." />
@@ -32,7 +32,7 @@
     shortDescription="Custom method for loading users. Must accept a String query and return List&lt;UserDTO&gt;. Type: Method Expression. Defaul: completeUser. Required: false." />
   <cc:attribute name="cache" type="java.lang.Boolean" default="true" shortDescription="Caches autocomplete search results when enabled. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="moreText" default="#{ivy.cms.co('/Dialogs/com/axonivy/portal/components/Common/More')}..." shortDescription="Text displayed for the 'More' link when results exceed the limit. Type: String. Default value: More.... Required: false." />
-  <cc:attribute name="queryDelay" default="300" shortDescription="Delay in milliseconds before sending the search query. Type: int. Default value: 300. Required: false." />
+  <cc:attribute name="queryDelay" default="300" type="java.lang.Integer" shortDescription="Delay in milliseconds before sending the search query. Type: int. Default value: 300. Required: false." />
   <cc:attribute name="maxResults" default="100" type="java.lang.Integer" shortDescription="Maximum number of results displayed in the dropdown. Type: int. Default value: 100. Required: false." />
   <cc:attribute name="hasCustomizedSelectionList" type="java.lang.Boolean" default="false" shortDescription="Displays a customized selection list when enabled. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="emptyMessage" shortDescription="Message displayed when no results are available. Type: String. Default value: No results. Required: false." 

--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/UserSelection/UserSelection.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/UserSelection/UserSelection.xhtml
@@ -39,7 +39,7 @@
     default="#{ivy.cms.co('/Labels/NoResults')}" />
 
   <!-- Avatar in Selection list attributes  -->
-  <cc:attribute name="isShowAvatarInSelectionList" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
+  <cc:attribute name="isShowAvatarInSelectionList" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
     shortDescription="Displays user avatars in the selection list when enabled. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="displayNameRenderedInSelectionList" type="java.lang.Boolean" default="true" shortDescription="Controls visibility of the user display name in the selection list. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="displayNameInSelectionListStyleClass" shortDescription="CSS style class for the user display name in the selection list. Type: String. Required: false." />
@@ -47,7 +47,7 @@
 
   <!-- Label attributes -->
   <cc:attribute name="label" shortDescription="Label text for the user selection component. Type: String. Required: false." />
-  <cc:attribute name="floatingLabel" shortDescription="Displays the label using floating style. Type: boolean. Default value: false. Required: false." />
+  <cc:attribute name="floatingLabel" type="java.lang.Boolean" shortDescription="Displays the label using floating style. Type: boolean. Default value: false. Required: false." />
   <cc:attribute name="labelStyleClass" shortDescription="CSS style class applied to the label. Type: String. Required: false." />
 
   <!-- Message attributes -->

--- a/AxonIvyPortal/portal-components/webContent/resources/components/avatar.xhtml
+++ b/AxonIvyPortal/portal-components/webContent/resources/components/avatar.xhtml
@@ -5,7 +5,7 @@
 <cc:interface>
   <cc:attribute name="securityMember" required="true" />
   <cc:attribute name="id" />
-  <cc:attribute name="renderedAvatar" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}" />
+  <cc:attribute name="renderedAvatar" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}" />
   <cc:attribute name="useLowercaseEmail" type="java.lang.Boolean" default="true" shortDescription="Convert the email address to lowercase before looking up the avatar." />
   <cc:attribute name="representName" />
   <cc:attribute name="showLabel" type="java.lang.Boolean" default="true" />

--- a/AxonIvyPortal/portal-components/webContent/resources/components/securityMemberNameAndAvatar.xhtml
+++ b/AxonIvyPortal/portal-components/webContent/resources/components/securityMemberNameAndAvatar.xhtml
@@ -6,17 +6,17 @@
   
 
 <cc:interface>
-  <cc:attribute name="isShowAvatar" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}" />
+  <cc:attribute name="isShowAvatar" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}" />
   <cc:attribute name="id" />
   <cc:attribute name="displayNameId" default="username" />
-  <cc:attribute name="displayName" required="true" />
+  <cc:attribute name="displayName" required="true" type="java.lang.String"/>
   <cc:attribute name="displayNameRendered" type="java.lang.Boolean" default="true" />
   <cc:attribute name="securityMember" required="true" />
-  <cc:attribute name="displayNameStyleClass" />
+  <cc:attribute name="displayNameStyleClass" type="java.lang.String"/>
   <cc:attribute name="containerStyleClass" />
   <cc:attribute name="representName" />
   <cc:attribute name="isStandAlone" type="java.lang.Boolean" default="true" />
-  <cc:attribute name="isShowTechnicalDisplayNameOnTooltip" default="#{portalComponentAvatarBean.getPortalShowTechnicalTooltipOrDefault(false)}" />
+  <cc:attribute name="isShowTechnicalDisplayNameOnTooltip" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowTechnicalTooltipOrDefault(false)}" />
   <cc:attribute name="showLabel" type="java.lang.Boolean" default="true"/>
 </cc:interface>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/component/ProcessInformation/ProcessInformation.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/component/ProcessInformation/ProcessInformation.xhtml
@@ -7,6 +7,7 @@
 	xmlns:pe="http://primefaces.org/ui/extensions"
 	xmlns:jsf="http://xmlns.jcp.org/jsf"
 	xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <h:body>
   <ui:composition template="/layouts/restricted/ProcessOverviewTemplate.xhtml">
     <ui:param name="processSteps" value="#{data.processSteps}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/component/ProcessInformation/ProcessInformation.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/component/ProcessInformation/ProcessInformation.xhtml
@@ -45,7 +45,7 @@
         rendered="#{!compactProcessWidgetBean.canStartProcess(data.selectedProcess)}" trackMouse="true" />
       </div>
       
-        <script>
+        <script type="text/javascript">
         function goBack() {
           window.history.back();
           if (event) {

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/error/ErrorPage/ErrorPage.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/error/ErrorPage/ErrorPage.xhtml
@@ -3,6 +3,7 @@
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:jsf="http://xmlns.jcp.org/jsf">
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <ui:param name="errorMessage" value="#{flash.keep.errorMessage}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/CaseDocuments/CaseDocuments.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/CaseDocuments/CaseDocuments.xhtml
@@ -3,6 +3,7 @@
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:pc="http://xmlns.jcp.org/jsf/composite/components">
+<!-- portalComponentUtilsBean: com.axonivy.portal.components.bean.PortalComponentUtilsBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <ui:param name="isWorkingOnATask" value="false" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/ForgotPassword/ForgotPassword.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/ForgotPassword/ForgotPassword.xhtml
@@ -27,7 +27,7 @@
   <h:outputStylesheet library="css" name="portal.css" />
   <h:outputStylesheet name="custom.css" library="ivy-branding" />
   
-  <script src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
+  <script type="text/javascript" src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
   <h:outputScript name="js/layout.js" library="#{ivyFreyaTheme.library}" />
   <h:outputScript name="responsive-toolkit.js" library="js" />
   <h:outputScript name="main.js" library="js" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/GlobalSearch/GlobalSearch.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/GlobalSearch/GlobalSearch.xhtml
@@ -96,7 +96,7 @@
     </div>
 
   </p:overlayPanel>
-  <script>
+  <script type="text/javascript">
       function showConfirmationDialog() {
           if (PrimeFaces.widgets['search-task-losing-confirmation-dialog']) {
               PF('search-task-losing-confirmation-dialog').show();

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/GlobalSearch/GlobalSearch.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/GlobalSearch/GlobalSearch.xhtml
@@ -8,7 +8,7 @@
   <cc:attribute name="isWorkingOnATask" type="java.lang.Boolean" />
   <cc:attribute name="case" />
   <cc:attribute name="task" />
-  <cc:attribute name="showQuickGlobalSearch" />
+  <cc:attribute name="showQuickGlobalSearch" type="java.lang.Boolean" />
 </cc:interface>
 <cc:implementation>
   <c:set var="task" value="#{cc.attrs.task}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/Login/Login.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/Login/Login.xhtml
@@ -2,6 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
+<!-- isNotRequiredLogin: java.lang.Boolean -->
 <h:head>
   <f:facet name="first">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/Login/Login.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/Login/Login.xhtml
@@ -29,7 +29,7 @@
   <h:outputStylesheet library="css" name="portal.css" />
   <h:outputStylesheet name="custom.css" library="ivy-branding" />
   
-  <script src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
+  <script type="text/javascript" src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
   <h:outputScript name="responsive-toolkit.js" library="js" />
   <h:outputScript name="main.js" library="js" />
   <h:outputScript name="portal.js" library="js" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/PasswordReset/PasswordReset.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/PasswordReset/PasswordReset.xhtml
@@ -25,7 +25,7 @@
   <h:outputStylesheet library="css" name="portal.css" />
   <h:outputStylesheet name="custom.css" library="ivy-branding" />
 
-  <script src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
+  <script type="text/javascript" src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
   <h:outputScript name="responsive-toolkit.js" library="js" />
   <h:outputScript name="main.js" library="js" />
   <h:outputScript name="portal.js" library="js" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/TaskDocuments/TaskDocuments.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/TaskDocuments/TaskDocuments.xhtml
@@ -3,7 +3,7 @@
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:pc="http://xmlns.jcp.org/jsf/composite/components">
-
+<!-- portalComponentUtilsBean: com.axonivy.portal.components.bean.PortalComponentUtilsBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <ui:param name="isWorkingOnATask" value="false" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardConfiguration/MenuDetailsDialog.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardConfiguration/MenuDetailsDialog.xhtml
@@ -3,7 +3,7 @@
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:pc="http://xmlns.jcp.org/jsf/composite/components"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- menuDetailsBean: com.axonivy.portal.bean.menu.MenuDetailsBean -->
 <ui:composition>
   <c:set var="isReadOnly" value="#{menuDetailsBean.readOnly}" />
   <c:set var="contentState" value="#{menuDetailsBean.contentState}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardConfiguration/PortalDashboardConfigurationActionSelection.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardConfiguration/PortalDashboardConfigurationActionSelection.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- isPublicDashboard: java.lang.Boolean -->
   <div class="ui-g">
     <div class="ui-g-12 dashboard-configuration__sub-header">
       <span class="sub-title">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/DashboardConfiguration/SelectAction')}</span>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardDetailModification/StandardWidgetItem.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardDetailModification/StandardWidgetItem.xhtml
@@ -2,6 +2,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
+<!-- sample: ch.ivy.addon.portalkit.dto.dashboard.WidgetSample -->
   <div class="col-12 md:col-6 lg:col-4">
     <p:commandLink styleClass="new-widget-dialog__item card js-widget block w-full h-full pl-0"
       ariaLabel="#{sample.name} #{sample.introduction}"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardDetailModification/StatisticWidgetItem.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardDetailModification/StatisticWidgetItem.xhtml
@@ -2,6 +2,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
+<!-- widget: com.axonivy.portal.bo.Statistic -->
   <div class="col-12 md:col-6 lg:col-4">
     <div class="new-widget-dialog__item new-widget-dialog__item--statistic-wrapper card block w-full h-full relative">
       <p:commandLink styleClass="new-widget-dialog__item-content js-widget block w-full h-full pl-0 pr-6"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseDashboardWidget/CaseFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseDashboardWidget/CaseFilter.xhtml
@@ -3,7 +3,7 @@
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- widget: ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget -->
 <h:panelGroup id="filter-container" layout="block" styleClass="widget-filter-panel">
   <f:event listener="#{caseWidgetUserFilterBean.preRender(widget)}" type="preRenderComponent" />
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseDashboardWidget/CaseInfo.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseDashboardWidget/CaseInfo.xhtml
@@ -2,7 +2,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:pc="http://xmlns.jcp.org/jsf/composite/components">
-
+<!-- widget: ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget -->
 <p:tab id="state-tab">
   <p:remoteCommand id="build-statistic-case-states-#{widget.id}" name="buildStatisticCaseStates#{widget.id}"
     async="true" process="@this" partialSubmit="true" immediate="true" global="false"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidgetConfiguration/CaseWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidgetConfiguration/CaseWidgetConfiguration.xhtml
@@ -4,7 +4,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="caseWidget" />
+  <cc:attribute name="caseWidget" type="ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget" />
   <cc:attribute name="managedBean" />
   <cc:attribute name="componentToUpdate" />
   <cc:attribute name="isReadOnlyMode" type="java.lang.Boolean" default="false"/>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/DashboardDetails/DashboardDetails.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/DashboardDetails/DashboardDetails.xhtml
@@ -6,7 +6,7 @@
   <cc:attribute name="detailDialogId" required="true" />
   <cc:attribute name="managedBean" required="true" />
   <cc:attribute name="title" required="true" />
-  <cc:attribute name="isPublicDashboard" required="true" />
+  <cc:attribute name="isPublicDashboard" type="java.lang.Boolean" required="true" />
   <cc:attribute name="componentToUpdate" />
   <cc:attribute name="isDashboardCreation" type="java.lang.Boolean" default="false" />
 </cc:interface>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/DashboardModification/DashboardModification.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/DashboardModification/DashboardModification.xhtml
@@ -4,7 +4,7 @@
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:pc="http://xmlns.jcp.org/jsf/composite/components">
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="isPublicDashboard"/>
+  <cc:attribute name="isPublicDashboard" type="java.lang.Boolean" />
   <cc:attribute name="listenerOnBackAction" />
   <cc:attribute name="componentToUpdateOnBackAction" />
 </cc:interface>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessDashboardWidget/ProcessDashboardWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessDashboardWidget/ProcessDashboardWidget.xhtml
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:h="http://xmlns.jcp.org/jsf/html"
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
+<!-- dashboardProcessBean: ch.ivy.addon.portalkit.bean.DashboardProcessBean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="index" required="true" />
   <cc:attribute name="widget" required="true" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessDashboardWidget/ProcessInfo.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessDashboardWidget/ProcessInfo.xhtml
@@ -1,7 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:h="http://xmlns.jcp.org/jsf/html"
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jsf="http://xmlns.jcp.org/jsf">
-
+<!-- widget: ch.ivy.addon.portalkit.dto.dashboard.CompactProcessDashboardWidget -->
 <p:tab id="type-tab">
   <p:remoteCommand id="build-statistic-process-type-#{widget.id}" name="buildStatisticProcessTypes#{widget.id}"
     async="true" actionListener="#{widget.buildProcessByTypeStatistic()}"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidget/CombinedModeProcess.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidget/CombinedModeProcess.xhtml
@@ -2,6 +2,8 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
+<!-- cloneWidgetBean: ch.ivy.addon.portal.generic.bean.CloneWidgetBean -->
+<!-- dashboardDetailModificationBean: ch.ivy.addon.portal.generic.bean.DashboardDetailModificationBean -->
 
 <!-- Action -->
 <h:panelGroup id="process-action" rendered="#{!isReadOnlyMode}" styleClass="process-grid-item__action--combined">

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidget/ImageModeProcess.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidget/ImageModeProcess.xhtml
@@ -1,6 +1,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!--  dashboardProcessBean: ch.ivy.addon.portalkit.bean.DashboardProcessBean -->
+<!--  process: ch.ivy.addon.portalkit.dto.dashboard.process.DashboardProcess -->
 <ui:composition>
   <c:set var="isExternalLink" value="#{dashboardProcessBean.isExternalLink(process)}" />
   <c:set var="isCaseMap" value="#{dashboardProcessBean.isCaseMap(process)}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidgetConfiguration/ProcessWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidgetConfiguration/ProcessWidgetConfiguration.xhtml
@@ -4,7 +4,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="processWidget" />
+  <cc:attribute name="processWidget" type="ch.ivy.addon.portalkit.dto.dashboard.ProcessDashboardWidget" />
   <cc:attribute name="managedBean" />
   <cc:attribute name="componentToUpdate" />
   <cc:attribute name="isPublicDashboard" type="java.lang.Boolean" default="true"/>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskDashboardWidget/TaskDashboardWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskDashboardWidget/TaskDashboardWidget.xhtml
@@ -11,8 +11,8 @@
   <c:set var="index" value="#{cc.attrs.index}" />
   <c:set var="widget" value="#{cc.attrs.widget}" />
   <c:set var="isReadOnlyMode" value="#{cc.attrs.isReadOnlyMode}"/>
-  <c:set var="isResizable" value="#{cc.attrs.widget.isResizable}"/>
-  <c:set var="isResizing" value="#{cc.attrs.widget.isResizing}"/>
+  <c:set var="isResizable" type="java.lang.Boolean" value="#{cc.attrs.widget.isResizable}"/>
+  <c:set var="isResizing" type="java.lang.Boolean" value="#{cc.attrs.widget.isResizing}"/>
 
   <ui:decorate template="/layouts/restricted/decorator/TableWidget.xhtml">
     <ui:param name="index" value="#{index}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskDashboardWidget/TaskFilter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskDashboardWidget/TaskFilter.xhtml
@@ -3,7 +3,8 @@
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- taskWidgetUserFilterBean: com.axonivy.portal.bean.dashboard.filter.TaskWidgetUserFilterBean -->
+<!-- widget: ch.ivy.addon.portalkit.dto.dashboard.TaskDashboardWidget -->
 <h:panelGroup id="filter-container" layout="block" styleClass="widget-filter-panel">
   <f:event listener="#{taskWidgetUserFilterBean.preRender(widget)}" type="preRenderComponent" />
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidgetConfiguration/TaskWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidgetConfiguration/TaskWidgetConfiguration.xhtml
@@ -4,7 +4,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="taskWidget" />
+  <cc:attribute name="taskWidget" type="ch.ivy.addon.portalkit.dto.dashboard.TaskDashboardWidget" />
   <cc:attribute name="managedBean" />
   <cc:attribute name="componentToUpdate" />
   <cc:attribute name="isReadOnlyMode" type="java.lang.Boolean" default="false"/>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeDashboardWidget/WelcomeDashboardWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeDashboardWidget/WelcomeDashboardWidget.xhtml
@@ -2,6 +2,11 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:jsf="http://xmlns.jcp.org/jsf">
+<!-- dashboardDetailModificationBean: ch.ivy.addon.portal.generic.bean.DashboardDetailModificationBean -->
+<!-- dashboardWelcomeWidgetBean: ch.ivy.addon.portalkit.bean.DashboardWelcomeWidgetBean -->
+<!-- cloneWidgetBean: ch.ivy.addon.portal.generic.bean.CloneWidgetBean -->
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
+<!-- hideActionButton: java.lang.Boolean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="index" required="true" />
   <cc:attribute name="widget" required="true" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeDashboardWidget/WelcomeDashboardWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeDashboardWidget/WelcomeDashboardWidget.xhtml
@@ -87,7 +87,7 @@
     <p:remoteCommand id="update-welcome-text-#{widget.id}-rc" name="updateWelcomeText_#{widget.internalId}" update="welcome-text welcome-text-dark-mode" process="@this" async="true"
       actionListener="#{dashboardWelcomeWidgetBean.updateWelcomeText(widget)}"
       oncomplete="WelcomeWidget.updateWelcomeTextStyles('#{htmlSanitizerBean.escapeForJS(widget.id)}','#{htmlSanitizerBean.escapeForJS(widget.welcomeTextColor)}', '#{htmlSanitizerBean.escapeForJS(widget.welcomeTextColorDarkMode)}', '#{htmlSanitizerBean.escapeForJS(widget.welcomeTextPosition)}','#{htmlSanitizerBean.escapeForJS(widget.welcomeTextSize)}');" />
-    <script>
+    <script type="text/javascript">
       $(document).ready(function() {
         WelcomeWidget.init('#{htmlSanitizerBean.escapeForJS(widget.id)}',
             '#{htmlSanitizerBean.escapeForJS(widget.welcomeTextColor)}',

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeWidgetConfiguration/WelcomeWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeWidgetConfiguration/WelcomeWidgetConfiguration.xhtml
@@ -279,7 +279,7 @@
     <p:remoteCommand name="initGreetingTexts" update="welcome-text-input-container"
       actionListener="#{dashboardWelcomeWidgetConfigurationBean.initClientTime()}"
       oncomplete="WelcomeWidgetConfiguration.updatePreviewText('#{widget.greeting}');" />
-    <script>
+    <script type="text/javascript">
       $(document).ready(function() {
        updateAll();
       });

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeWidgetConfiguration/WelcomeWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeWidgetConfiguration/WelcomeWidgetConfiguration.xhtml
@@ -4,7 +4,8 @@
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:cc="http://xmlns.jcp.org/jsf/composite"
   xmlns:jsf="http://xmlns.jcp.org/jsf" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
-
+<!-- dashboardWelcomeWidgetConfigurationBean: ch.ivy.addon.portalkit.bean.DashboardWelcomeWidgetConfigurationBean -->
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="widget" />
   <cc:attribute name="componentToUpdate" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/AbsenceManagement/AbsenceManagement.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/AbsenceManagement/AbsenceManagement.xhtml
@@ -2,6 +2,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:pc="http://xmlns.jcp.org/jsf/composite/components">
+<!-- portalComponentAvatarBean: com.axonivy.portal.components.bean.PortalComponentAvatarBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <ui:param name="viewName" value="ABSENCES_MANAGEMENT" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/PasswordResetErrorPage/PasswordResetErrorPage.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/PasswordResetErrorPage/PasswordResetErrorPage.xhtml
@@ -2,6 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions">
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="message" />
 </cc:interface>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemDetails/CaseItemDetails.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemDetails/CaseItemDetails.xhtml
@@ -5,7 +5,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:jsf="http://xmlns.jcp.org/jsf">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="case" required="true"/>
+  <cc:attribute name="case" type="ch.ivyteam.ivy.workflow.ICase" required="true"/>
   <cc:attribute name="showItemBackButton" type="java.lang.Boolean" default="true" />
   <cc:attribute name="isTaskStartedInDetails" type="java.lang.Boolean" default="false" />
   <cc:attribute name="inFrame" type="java.lang.Boolean" default="false"/>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemRelatedCases/CaseAction.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemRelatedCases/CaseAction.xhtml
@@ -3,7 +3,7 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:jsf="http://xmlns.jcp.org/jsf">
-
+<!-- task: ch.ivyteam.ivy.workflow.ITask -->
 <ui:composition>
   <div id="action-cell" class="task-header-action-cell">
     <div class="action-container">

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseWidget/CaseWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseWidget/CaseWidget.xhtml
@@ -6,7 +6,7 @@
 
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="dataModel" shortDescription="List of cases to be displayed" />
-  <cc:attribute name="chunkSize" shortDescription="Number of items to fetch for each lazy load" default="25" />
+  <cc:attribute name="chunkSize" type="java.lang.Integer" shortDescription="Number of items to fetch for each lazy load" default="25" />
   <cc:attribute name="emptyMessage"
     default="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portalkit/component/CaseWidget/defaultEmptyMessage')}"
     shortDescription="A message when the cases are empty" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/GlobalAjaxStatus/GlobalAjaxStatus.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/GlobalAjaxStatus/GlobalAjaxStatus.xhtml
@@ -2,7 +2,7 @@
   xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:p="http://primefaces.org/ui" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:cc="http://xmlns.jcp.org/jsf/composite">
-
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="styleClass" />
   <cc:attribute name="widgetVar" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/GlobalFooterInfo/GlobalFooterInfo.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/GlobalFooterInfo/GlobalFooterInfo.xhtml
@@ -3,7 +3,7 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
   xmlns:jsf="http://xmlns.jcp.org/jsf">
-
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
 </cc:interface>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/PageFooter/PageFooter.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/PageFooter/PageFooter.xhtml
@@ -3,7 +3,7 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
   xmlns:jsf="http://xmlns.jcp.org/jsf">
-
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
 </cc:interface>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/PageHeader/PageHeader.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/PageHeader/PageHeader.xhtml
@@ -4,6 +4,7 @@
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
 
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
 </cc:interface>
 <cc:implementation>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/ProcessWidget/ProcessImageMode.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/ProcessWidget/ProcessImageMode.xhtml
@@ -1,6 +1,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- process: package ch.ivy.addon.portalkit.bo.Process -->
 <ui:composition>
   <c:set var="isExternalLink" value="#{processWidgetBean.isExternalLink(process)}" />
   <c:set var="isCaseMap" value="#{processWidgetBean.isCaseMap(process)}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/ProcessWidget/ProcessListMode.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/ProcessWidget/ProcessListMode.xhtml
@@ -2,6 +2,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
 
+<!-- process: package ch.ivy.addon.portalkit.bo.Process -->
 <ui:composition>
   <c:set var="isExternalLink" value="#{processWidgetBean.isExternalLink(process)}" />
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/ProcessWidget/ProcessWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/ProcessWidget/ProcessWidget.xhtml
@@ -129,7 +129,7 @@
 
   <ui:include src="ProcessWidgetDialogs.xhtml" />
 
-  <script>
+  <script type="text/javascript">
       var processWidget = new ProcessWidget();
       $(function() {
         processWidget.setupScrollbar();

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/SideStep/SideStep.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/SideStep/SideStep.xhtml
@@ -14,7 +14,7 @@
   <cc:attribute name="componentToUpdate" default="" />
   <cc:attribute name="destroyTaskDialogComponent" default="" />
   <cc:attribute name="buttonStyleClass" />
-  <cc:attribute name="renderedAdditionalAction" shortDescription="Control display side steps" />
+  <cc:attribute name="renderedAdditionalAction" type="java.lang.Boolean" shortDescription="Control display side steps" />
   <cc:attribute name="currentPortalPage" default="TASK_LIST" />
   <cc:attribute name="showDetailOption" type="java.lang.Boolean" default="false" shortDescription="Display go to task detail option" />
   <cc:attribute name="dataModel" shortDescription="Data model of task list" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskWidget/TaskWidget.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskWidget/TaskWidget.xhtml
@@ -8,7 +8,7 @@
   <cc:attribute name="styleClass" />
   <cc:attribute name="listHeaderStyleClass" />
   <cc:attribute name="dataModel" />
-  <cc:attribute name="chunkSize" shortDescription="Number of items to fetch for each lazy load" default="25" />
+  <cc:attribute name="chunkSize" type="java.lang.Integer" shortDescription="Number of items to fetch for each lazy load" default="25" />
   <cc:attribute name="title" default="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/tasks')}" />
   <cc:attribute name="compactMode" default="true" type="java.lang.Boolean" />
   <cc:attribute name="selectedTaskId" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/dashboard/widget/CategoryFilterColumn/CategoryFilterColumn.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/dashboard/widget/CategoryFilterColumn/CategoryFilterColumn.xhtml
@@ -8,7 +8,7 @@
   <cc:attribute name="categoryTree" required="true"/>
   <cc:attribute name="categoryNodeSelection" required="true"/>
   <cc:attribute name="displaySelectedCategories" required="true"/>
-  <cc:attribute name="showUnselectableCheckbox"/>
+  <cc:attribute name="showUnselectableCheckbox" type="java.lang.Boolean"/>
   <cc:attribute name="containerStyleClass" />
   <cc:attribute name="inputCategoryStyleClass" />
   <cc:attribute name="overlayCategoryStyleClass" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/process/ProcessGridItem/ProcessGridItem.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/process/ProcessGridItem/ProcessGridItem.xhtml
@@ -16,11 +16,11 @@
   <cc:attribute name="oncompleteRemoveProcess" shortDescription="Javascript handler to execute when clicking on the Remove button is completed."/>
   <cc:attribute name="componentToUpdateOnRemoveProcess" shortDescription="Client side id of the component(s) to be updated after clicked on the Remove button" />
   <cc:attribute name="removeActionListener" shortDescription="An actionlistener to process when the Remove button is executed." />
-  <cc:attribute name="readOnlyMode" />
+  <cc:attribute name="readOnlyMode" type="java.lang.Boolean" />
   <cc:attribute name="ableToEdit" />
   <cc:attribute name="processStyleClass" />
   <cc:attribute name="processIconStyleClass" />
-  <cc:attribute name="isInConfiguration"/>
+  <cc:attribute name="isInConfiguration" type="java.lang.Boolean" />
 </cc:interface>
 
 <cc:implementation>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/feature/WarnOnClosingBrowserTab/WarnOnClosingBrowserTab.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/feature/WarnOnClosingBrowserTab/WarnOnClosingBrowserTab.xhtml
@@ -12,7 +12,7 @@
 	</cc:interface>
 	
 	<cc:implementation>
-		<script>
+		<script type="text/javascript">
 			var confirmMessage = "#{cc.attrs.confirmMessage}";
 			var showConfirmDialogBeforeUnload = true;
 			

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/LogoutSetting/LogoutSetting.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/LogoutSetting/LogoutSetting.xhtml
@@ -68,7 +68,7 @@
     </h:form>
   </p:confirmDialog>
 
-  <script>
+  <script type="text/javascript">
 	function returnHomePage() {
       showConfirmDialogBeforeUnload = false;
       window.open('#{htmlSanitizerBean.escapeForJS(userMenuBean.logoutPage)}', '_self');

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/LogoutSetting/LogoutSetting.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/LogoutSetting/LogoutSetting.xhtml
@@ -7,7 +7,7 @@
   xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="task" />
   <cc:attribute name="isWorkingOnATask" type="java.lang.Boolean" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/PasswordSetting/PasswordSetting.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/PasswordSetting/PasswordSetting.xhtml
@@ -5,6 +5,7 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
 
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="dialogName" shortDescription="Name of setting dialog's widget that contains this component" />
 </cc:interface>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/PasswordReset/PasswordReset.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/PasswordReset/PasswordReset.xhtml
@@ -5,6 +5,7 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
 
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
 </cc:interface>
 

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/component/ExpiryResponsible/ExpiryResponsible.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/component/ExpiryResponsible/ExpiryResponsible.xhtml
@@ -2,7 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:p="http://primefaces.org/ui"
   xmlns:pc="http://xmlns.jcp.org/jsf/composite/components" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- portalComponentAvatarBean: com.axonivy.portal.components.bean.PortalComponentAvatarBean -->
 <cc:interface>
   <cc:attribute name="expiryResponsibles" type="ch.ivyteam.ivy.workflow.task.expiry.responsible.ExpiryResponsibles" required="true" />
   <cc:attribute name="popupLink" type="java.lang.Boolean" default="false"/>

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/component/NotificationFullPage/NotificationFullPage.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/component/NotificationFullPage/NotificationFullPage.xhtml
@@ -2,6 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions">
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <ui:param name="unreadNotificationsId" value="#{p:resolveFirstComponentWithId('topbar-unread-notifications-container', view).clientId}" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/component/ShareLinkDialog/ShareLinkDialog.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/component/ShareLinkDialog/ShareLinkDialog.xhtml
@@ -9,7 +9,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:pc="http://xmlns.jcp.org/jsf/composite/components"
   xmlns:jsf="http://xmlns.jcp.org/jsf">
-
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="shareDialogId" required="true" />
   <cc:attribute name="title" required="true" />

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/DashboardImportDetails/DashboardImportDetails.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/DashboardImportDetails/DashboardImportDetails.xhtml
@@ -13,7 +13,7 @@
 <cc:interface componentType="IvyComponent">
   <cc:attribute name="importDialogId" required="true" />
   <cc:attribute name="managedBean" required="true" />
-  <cc:attribute name="isPublicDashboard" required="true" />
+  <cc:attribute name="isPublicDashboard" type="java.lang.Boolean" required="true" />
 </cc:interface>
 
 <cc:implementation>

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NewsWidget/NewsItem.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NewsWidget/NewsItem.xhtml
@@ -3,7 +3,7 @@
   xmlns:cc="http://xmlns.jcp.org/jsf/composite" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:pe="http://primefaces.org/ui/extensions"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <div class="news-item__container">
   <c:set var="newsItemId" value="#{widget.id}__#{indexVar}" />
   <div id="#{newsItemId}" class="news-item">

--- a/AxonIvyPortal/portal/webContent/layouts/BasicTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/BasicTemplate.xhtml
@@ -48,7 +48,7 @@
   <!-- themBean: com.axonivy.portal.bean.ThemeBean -->
   <f:attribute name="primefaces.THEME" value="#{themeBean.theme}" />
   <link rel="shortcut icon" href="#{resource['ivy-branding:favicon']}" />
-  <c:set var="loadGridStack" value="#{loadGridStack == 'true' ? 'true' : 'false'}" />
+  <c:set var="loadGridStack" value="#{loadGridStack == 'true' ? true : false}" />
   <!-- GridStack resources -->
   <h:outputStylesheet library="css" name="gridstack.min.css" rendered="#{loadGridStack}" />
   <h:outputStylesheet library="css" name="gridstack-extra.min.css" rendered="#{loadGridStack}" />

--- a/AxonIvyPortal/portal/webContent/layouts/BasicTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/BasicTemplate.xhtml
@@ -45,6 +45,7 @@
     </ui:insert> - #{masterDataBean.portalApplicationName}
   </title>
 
+  <!-- themBean: com.axonivy.portal.bean.ThemeBean -->
   <f:attribute name="primefaces.THEME" value="#{themeBean.theme}" />
   <link rel="shortcut icon" href="#{resource['ivy-branding:favicon']}" />
   <c:set var="loadGridStack" value="#{loadGridStack == 'true' ? 'true' : 'false'}" />
@@ -55,7 +56,7 @@
   <!-- FREYA IMPORT -->
   <h:outputStylesheet name="#{ivyFreyaTheme.layout}" library="#{ivyFreyaTheme.library}" />
   <h:outputScript name="js/layout.js" library="#{ivyFreyaTheme.library}" />
-  <script src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
+  <script type="text/javascript" src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
   <h:outputStylesheet library="css" name="portal-root-variables.css" />
   <h:outputStylesheet library="css" name="portal-variables-#{ivyFreyaTheme.mode}.css" />
   <h:outputStylesheet library="primeflex" name="primeflex-3.min.css" />

--- a/AxonIvyPortal/portal/webContent/layouts/SearchResultsTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/SearchResultsTemplate.xhtml
@@ -150,7 +150,7 @@
           
         </p:tabView>
       </div>
-      <script>
+      <script type="text/javascript">
        $(function(){
           $('#global-search-component\\:global-search-data').val($('.js-filter-process-widget-list-item').val());
         });

--- a/AxonIvyPortal/portal/webContent/layouts/frame-10.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/frame-10.xhtml
@@ -51,7 +51,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
@@ -2,6 +2,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component"
   xmlns:p="http://primefaces.org/ui" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:pc="http://xmlns.jcp.org/jsf/composite/components" >
+<!-- abstractTaskTemplateBean: ch.ivy.addon.portal.generic.bean.AbstractTaskTemplateBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <!-- THIS TEMPLATE IS ONLY USED BY PORTAL. DON'T USE IT -->

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/AbstractTaskTemplate.xhtml
@@ -9,7 +9,7 @@
     <ui:param name="viewName" value="#{empty viewName ? 'TASK_DETAIL' : viewName}" />
     <ui:param name="currentTask" value="#{not empty abstractTaskTemplateBean.task ? abstractTaskTemplateBean.task : task}" />
     <ui:define name="pageContent">
-      <script>
+      <script type="text/javascript">
         function backToPrevPage(isHistoryBack) {
           if (document.referrer &amp;&amp; isHistoryBack) {
             window.history.back();

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
@@ -2,7 +2,7 @@
   xmlns:ui="http://xmlns.jcp.org/jsf/facelets" xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:jsf="http://xmlns.jcp.org/jsf"
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core">
-
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <ui:define name="head">

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
@@ -17,7 +17,7 @@
 
 
     <ui:define name="pageContent">
-        <script>
+        <script type="text/javascript">
           function initStatistics() {
             initClientCharts("#{managedBean.statisticApiUri}" , "#{managedBean.getSupportedUserLanguage()}", "#{dateTimePatternBean.datePattern}", "#{localeBean.locale}");
           }

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameTaskTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameTaskTemplate.xhtml
@@ -93,7 +93,7 @@
     <ui:param name="taskIcon" value="#{iFrameTaskTemplateBean.taskIcon}" />
 
     <ui:define name="content">
-      <script>
+      <script type="text/javascript">
         $(document).ready(function() {
           var taskUrl = '#{htmlSanitizerBean.escapeForJS(iFrameTaskTemplateBean.taskUrl)}';
           if (!taskUrl) {

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameTaskTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameTaskTemplate.xhtml
@@ -92,6 +92,7 @@
     <ui:param name="taskName" value="#{iFrameTaskTemplateBean.taskName}" />
     <ui:param name="taskIcon" value="#{iFrameTaskTemplateBean.taskIcon}" />
 
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
     <ui:define name="content">
       <script type="text/javascript">
         $(document).ready(function() {

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameWithoutMenuTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameWithoutMenuTemplate.xhtml
@@ -36,7 +36,7 @@
 
   <h:outputStylesheet name="custom.css" library="ivy-branding" />
 
-  <c:set var="loadPortalScript" value="#{loadPortalScript == 'false' ? 'false' : 'true'}" />
+  <c:set var="loadPortalScript" value="#{loadPortalScript == 'false' ? false : true}" />
   <h:outputScript name="responsive-toolkit.js" library="js" />
   <h:outputScript name="main.js" library="js" rendered="#{loadPortalScript}" />
   <h:outputScript name="portal.js" library="js" rendered="#{loadPortalScript}" />
@@ -44,6 +44,7 @@
 
 <h:body styleClass="iframe-body">
   <h:panelGroup layout="block" styleClass="layout-main js-layout-main portal-layout-container">
+    <!-- layoutContentStyleClass: java.lang.String -->
     <div id="main-area-panel"
       class="layout-content js-layout-content #{layoutContentStyleClass}">
       <ui:insert name="pageContent" />

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameWithoutMenuTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/IFrameWithoutMenuTemplate.xhtml
@@ -25,7 +25,7 @@
   <!-- FREYA IMPORT -->
   <h:outputStylesheet name="#{ivyFreyaTheme.layout}" library="#{ivyFreyaTheme.library}" />
   <h:outputScript name="js/layout.js" library="#{ivyFreyaTheme.library}" />
-  <script src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
+  <script type="text/javascript" src="#{resource['ivy-webcontent:layouts/js/cookie-helper.js']}" />
 
   <h:outputStylesheet library="css" name="utility.css" />
   <h:outputStylesheet library="css" name="portal-root-variables.css" />

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/ProcessOverviewTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/ProcessOverviewTemplate.xhtml
@@ -3,6 +3,7 @@
   xmlns:f="http://xmlns.jcp.org/jsf/core" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:p="http://primefaces.org/ui" xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
   xmlns:ic="http://ivyteam.ch/jsf/component">
+<!-- htmlSanitizerBean: com.axonivy.portal.components.bean.HtmlSanitizerBean -->
 <h:body>
   <ui:composition template="/layouts/BasicTemplate.xhtml">
     <ui:define name="pageContent">

--- a/Showcase/InternalSupport/src_hd/internaltest/ui/approveLeave/approveLeave.xhtml
+++ b/Showcase/InternalSupport/src_hd/internaltest/ui/approveLeave/approveLeave.xhtml
@@ -2,6 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions">
+<!-- dateTimePatternBean: ch.ivy.addon.portalkit.bean.DateTimePatternBean -->
 <h:body>
   <ui:composition template="/layouts/frame-10-full-width.xhtml">
     <ui:define name="errorsZone">

--- a/Showcase/InternalSupport/webContent/layouts/frame-10-full-width.xhtml
+++ b/Showcase/InternalSupport/webContent/layouts/frame-10-full-width.xhtml
@@ -51,7 +51,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->

--- a/Showcase/portal-components-examples/src_hd/com/axonivy/portal/components/examples/leaverequest/LeaveRequestSummary/LeaveRequestSummary.xhtml
+++ b/Showcase/portal-components-examples/src_hd/com/axonivy/portal/components/examples/leaverequest/LeaveRequestSummary/LeaveRequestSummary.xhtml
@@ -2,6 +2,7 @@
   xmlns:h="http://xmlns.jcp.org/jsf/html" xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
   xmlns:ic="http://ivyteam.ch/jsf/component" xmlns:p="http://primefaces.org/ui"
   xmlns:pe="http://primefaces.org/ui/extensions" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions">
+<!-- portalComponentUtilsBean: com.axonivy.portal.components.bean.PortalComponentUtilsBean -->
 <h:body>
   <ui:composition template="/layouts/frame-10.xhtml">
     <ui:define name="title">#{ivy.cms.co("/Labels/LeaveRequest/LeaveSteps/approvalResult")}</ui:define>

--- a/Showcase/portal-components-examples/webContent/layouts/frame-10-full-width.xhtml
+++ b/Showcase/portal-components-examples/webContent/layouts/frame-10-full-width.xhtml
@@ -51,7 +51,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->

--- a/Showcase/portal-components-examples/webContent/layouts/frame-10.xhtml
+++ b/Showcase/portal-components-examples/webContent/layouts/frame-10.xhtml
@@ -51,7 +51,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->

--- a/Showcase/portal-developer-examples/src_hd/com/axonivy/portal/developerexamples/testdata/Review/Review.xhtml
+++ b/Showcase/portal-developer-examples/src_hd/com/axonivy/portal/developerexamples/testdata/Review/Review.xhtml
@@ -99,7 +99,7 @@
           <p:commandButton id="close-btn" value="Close" actionListener="#{logic.close}" update="@(form)" />
         </h:panelGroup>
       </h:form>
-      <script>
+      <script type="text/javascript">
         window.processSteps = ["Create Investment Request", "Approve Investment Request", "Review Request"];
         window.currentProcessStep = 2;
         window.isShowAllSteps = true;

--- a/Showcase/portal-developer-examples/webContent/layouts/frame-10-full-width.xhtml
+++ b/Showcase/portal-developer-examples/webContent/layouts/frame-10-full-width.xhtml
@@ -51,7 +51,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->

--- a/Showcase/portal-developer-examples/webContent/layouts/frame-10.xhtml
+++ b/Showcase/portal-developer-examples/webContent/layouts/frame-10.xhtml
@@ -52,7 +52,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->

--- a/Showcase/portal-user-examples/webContent/layouts/frame-10.xhtml
+++ b/Showcase/portal-user-examples/webContent/layouts/frame-10.xhtml
@@ -51,7 +51,7 @@ and refence it below in the head part.
   </ui:insert>
 
   <!-- optional Portal parameters:
-  <script>
+  <script type="text/javascript">
     window.
   </script>
   -->


### PR DESCRIPTION
**Part 2 of the IVYPORTAL-20448 warning-reduction stack** — depends on #3535; merge after it. The diff shown is only this PR's increment on top of #3535 (~35 files).

Adds the JS-parser-facing warning fixes across all projects, same behavior-neutral standard as #3535:

- add `type="text/javascript"` to `<script>` tags flagged by the validator
- add `type` to the remaining `cc:attribute` declarations not covered by #3535
- restore CRLF line endings in `Filter.xhtml`

No runtime behavior change — all edits are declarations/type hints the XHTML validator wants. Exclusions and the `onstart` follow-up are as stated in #3535.