### PR TITLE
IVYPORTAL-20448 Safe reduce warning: continue add missing type

### DIFF
--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/RoleSelection/RoleSelection.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/RoleSelection/RoleSelection.xhtml
@@ -45,7 +45,7 @@
     default="#{ivy.cms.co('/Labels/NoResults')}" />
 
   <!-- Avatar in Selection list attributes  -->
-  <cc:attribute name="isShowAvatarInSelectionList" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
+  <cc:attribute name="isShowAvatarInSelectionList" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
     shortDescription="Displays role avatars in the selection list when enabled. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="displayNameRenderedInSelectionList" type="java.lang.Boolean" default="true"
     shortDescription="Controls visibility of the role display name in the selection list. Type: boolean. Default value: true. Required: false." />

--- a/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/UserSelection/UserSelection.xhtml
+++ b/AxonIvyPortal/portal-components/src_hd/com/axonivy/portal/components/UserSelection/UserSelection.xhtml
@@ -39,7 +39,7 @@
     default="#{ivy.cms.co('/Labels/NoResults')}" />
 
   <!-- Avatar in Selection list attributes  -->
-  <cc:attribute name="isShowAvatarInSelectionList" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
+  <cc:attribute name="isShowAvatarInSelectionList" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}"
     shortDescription="Displays user avatars in the selection list when enabled. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="displayNameRenderedInSelectionList" type="java.lang.Boolean" default="true" shortDescription="Controls visibility of the user display name in the selection list. Type: boolean. Default value: true. Required: false." />
   <cc:attribute name="displayNameInSelectionListStyleClass" shortDescription="CSS style class for the user display name in the selection list. Type: String. Required: false." />

--- a/AxonIvyPortal/portal-components/webContent/resources/components/securityMemberNameAndAvatar.xhtml
+++ b/AxonIvyPortal/portal-components/webContent/resources/components/securityMemberNameAndAvatar.xhtml
@@ -6,17 +6,17 @@
   
 
 <cc:interface>
-  <cc:attribute name="isShowAvatar" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}" />
+  <cc:attribute name="isShowAvatar" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowAvatarSettingOrDefault(true)}" />
   <cc:attribute name="id" />
   <cc:attribute name="displayNameId" default="username" />
-  <cc:attribute name="displayName" required="true" />
+  <cc:attribute name="displayName" required="true" type="java.lang.String"/>
   <cc:attribute name="displayNameRendered" type="java.lang.Boolean" default="true" />
   <cc:attribute name="securityMember" required="true" />
-  <cc:attribute name="displayNameStyleClass" />
+  <cc:attribute name="displayNameStyleClass" type="java.lang.String"/>
   <cc:attribute name="containerStyleClass" />
   <cc:attribute name="representName" />
   <cc:attribute name="isStandAlone" type="java.lang.Boolean" default="true" />
-  <cc:attribute name="isShowTechnicalDisplayNameOnTooltip" default="#{portalComponentAvatarBean.getPortalShowTechnicalTooltipOrDefault(false)}" />
+  <cc:attribute name="isShowTechnicalDisplayNameOnTooltip" type="java.lang.Boolean" default="#{portalComponentAvatarBean.getPortalShowTechnicalTooltipOrDefault(false)}" />
   <cc:attribute name="showLabel" type="java.lang.Boolean" default="true"/>
 </cc:interface>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidgetConfiguration/CaseWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CaseWidgetConfiguration/CaseWidgetConfiguration.xhtml
@@ -4,7 +4,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="caseWidget" />
+  <cc:attribute name="caseWidget" type="ch.ivy.addon.portalkit.dto.dashboard.CaseDashboardWidget" />
   <cc:attribute name="managedBean" />
   <cc:attribute name="componentToUpdate" />
   <cc:attribute name="isReadOnlyMode" type="java.lang.Boolean" default="false"/>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidgetConfiguration/ProcessWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidgetConfiguration/ProcessWidgetConfiguration.xhtml
@@ -4,7 +4,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="processWidget" />
+  <cc:attribute name="processWidget" type="ch.ivy.addon.portalkit.dto.dashboard.ProcessDashboardWidget" />
   <cc:attribute name="managedBean" />
   <cc:attribute name="componentToUpdate" />
   <cc:attribute name="isPublicDashboard" type="java.lang.Boolean" default="true"/>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidgetConfiguration/TaskWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/TaskWidgetConfiguration/TaskWidgetConfiguration.xhtml
@@ -4,7 +4,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions" xmlns:pt="http://xmlns.jcp.org/jsf/passthrough">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="taskWidget" />
+  <cc:attribute name="taskWidget" type="ch.ivy.addon.portalkit.dto.dashboard.TaskDashboardWidget" />
   <cc:attribute name="managedBean" />
   <cc:attribute name="componentToUpdate" />
   <cc:attribute name="isReadOnlyMode" type="java.lang.Boolean" default="false"/>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemDetails/CaseItemDetails.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemDetails/CaseItemDetails.xhtml
@@ -5,7 +5,7 @@
   xmlns:c="http://xmlns.jcp.org/jsp/jstl/core" xmlns:jsf="http://xmlns.jcp.org/jsf">
 
 <cc:interface componentType="IvyComponent">
-  <cc:attribute name="case" required="true"/>
+  <cc:attribute name="case" type="ch.ivyteam.ivy.workflow.ICase" required="true"/>
   <cc:attribute name="showItemBackButton" type="java.lang.Boolean" default="true" />
   <cc:attribute name="isTaskStartedInDetails" type="java.lang.Boolean" default="false" />
   <cc:attribute name="inFrame" type="java.lang.Boolean" default="false"/>


### PR DESCRIPTION
Continues the IVYPORTAL-20448 warning-reduction stack (behavior-neutral).

Stacked on #3539: adds `type="java.lang.String"` to the `displayName` cc:attribute and `type="java.lang.Boolean"` to `isShowTechnicalDisplayNameOnTooltip` in `securityMemberNameAndAvatar.xhtml`.