### PR TITLE
Prep jakarta update

### DIFF
--- a/Showcase/portal-user-examples/src/com/axonivy/portal/userexamples/bean/CaseMapDetailBean.java
+++ b/Showcase/portal-user-examples/src/com/axonivy/portal/userexamples/bean/CaseMapDetailBean.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import com.axonivy.portal.userexamples.dto.CaseMapDetail;
 
-@ManagedBean(name = "caseMapDetailBean")
+@ManagedBean(name = "exampleCaseMapDetailBean")
 @ViewScoped
 public class CaseMapDetailBean implements Serializable {
   private static final long serialVersionUID = 1L;

--- a/Showcase/portal-user-examples/src_hd/com/axonivy/portal/userexamples/credit/LendingDetail/LendingDetail.xhtml
+++ b/Showcase/portal-user-examples/src_hd/com/axonivy/portal/userexamples/credit/LendingDetail/LendingDetail.xhtml
@@ -6,7 +6,7 @@
   <ui:composition template="/layouts/restricted/CaseMapDetailTemplate.xhtml">
     <ui:param name="caseMapDetail" value="#{data.caseMapDetail}" />
     <ui:param name="stageIndex" value="#{data.stageIndex}" />
-    <ui:define name="pageTitle">#{caseMapDetailBean.getDisplayStage(caseMapDetail,stageIndex)}</ui:define>
+    <ui:define name="pageTitle">#{exampleCaseMapDetailBean.getDisplayStage(caseMapDetail,stageIndex)}</ui:define>
     <ui:define name="header">
       <div class="ui-g-1 ui-xl-1 ui-lg-1 ui-md-2 ui-sm-3">
         <p:graphicImage library="ivy-cms" name="#{caseMapDetail.icon}" />
@@ -34,13 +34,13 @@
           id="previous-stage"
           actionListener="#{logic.navigate(data.caseMapDetail, data.stageIndex - 1)}" 
           rendered="#{stageIndex > 0}"/>
-        <p:spacer width="10rem" rendered="#{caseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
+        <p:spacer width="10rem" rendered="#{exampleCaseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
         <p:commandLink value="#{ivy.cms.co('/Labels/NextStage')}" 
           actionListener="#{logic.navigate(data.caseMapDetail, data.stageIndex + 1)}"
           id="next-stage" 
-          rendered="#{caseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
-        <p:spacer width="5rem" rendered="#{caseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
-        <i class="ti ti-chevron-right ui-md-hidden ui-sm-hidden" style="color:var(--primary-color);" jsf:rendered="#{caseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
+          rendered="#{exampleCaseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
+        <p:spacer width="5rem" rendered="#{exampleCaseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
+        <i class="ti ti-chevron-right ui-md-hidden ui-sm-hidden" style="color:var(--primary-color);" jsf:rendered="#{exampleCaseMapDetailBean.renderNextLink(caseMapDetail,stageIndex)}"/>
       </div>
     </ui:define>
     
@@ -50,7 +50,7 @@
         actionListener="#{logic.cancel}" />
       <p:spacer width="20px" />
       <p:commandButton value="#{ivy.cms.co('/Labels/Start')} #{caseMapDetail.name}"
-        actionListener="#{caseMapDetailBean.startCaseMap(caseMapDetail.startLink)}" />
+        actionListener="#{exampleCaseMapDetailBean.startCaseMap(caseMapDetail.startLink)}" />
       </h:form>
     </ui:define>
   </ui:composition>

--- a/Showcase/portal-user-examples/webContent/layouts/restricted/CaseMapDetailTemplate.xhtml
+++ b/Showcase/portal-user-examples/webContent/layouts/restricted/CaseMapDetailTemplate.xhtml
@@ -26,12 +26,12 @@
               </ui:insert>
               <div class="ui-g-12">
                 <div class="ui-g-12">
-                  <h:outputText value="#{caseMapDetailBean.getDisplayStage(caseMapDetail,stageIndex)}"
+                  <h:outputText value="#{exampleCaseMapDetailBean.getDisplayStage(caseMapDetail,stageIndex)}"
                     styleClass="title-text" id="stage-#{stageIndex}-name" />
                 </div>
 
                 <!-- PROCESS -->
-                <ui:repeat var="process" value="#{caseMapDetailBean.getProcessOfStage(caseMapDetail, stageIndex)}"
+                <ui:repeat var="process" value="#{exampleCaseMapDetailBean.getProcessOfStage(caseMapDetail, stageIndex)}"
                   varStatus="processStatus">
                   <h:panelGroup layout="block" styleClass="ui-g-4 ui-xl-4 ui-lg-6 ui-md-6 ui-sm-12 ">
                     <div class="ui-g-12">
@@ -45,7 +45,7 @@
                           <div class="card ui-g-12 description-content height-100">
 
                             <ui:repeat var="desc"
-                              value="#{caseMapDetailBean.getProcessDescription(caseMapDetail, process)}">
+                              value="#{exampleCaseMapDetailBean.getProcessDescription(caseMapDetail, process)}">
                               <div class="ui-g-12">
                                 <div class="ui-g-2 TexAlCenter">
                                   <p:graphicImage library="ivy-cms" name="/Images/check-circle-1" height="20rem" />
@@ -62,7 +62,7 @@
                   </h:panelGroup>
                 </ui:repeat>
                 <!-- SIDE STEP -->
-                <ui:repeat var="process" value="#{caseMapDetailBean.getSideStepOfStage(caseMapDetail, stageIndex)}">
+                <ui:repeat var="process" value="#{exampleCaseMapDetailBean.getSideStepOfStage(caseMapDetail, stageIndex)}">
                   <h:panelGroup layout="block" styleClass="ui-g-4 ui-xl-4 ui-lg-6 ui-md-12 ui-sm-12 side-step-panel">
                     <div class="ui-g-12">
                       <div class="dropdown side-step-info ">
@@ -87,7 +87,7 @@
                           <div class="card ui-g-12 description-content">
 
                             <ui:repeat var="desc"
-                              value="#{caseMapDetailBean.getProcessDescription(caseMapDetail, process)}">
+                              value="#{exampleCaseMapDetailBean.getProcessDescription(caseMapDetail, process)}">
                               <div class="ui-g-12">
                                 <div class="ui-g-2 TexAlCenter">
                                   <p:graphicImage library="ivy-cms" name="/Images/check-circle-1" height="20rem" />

--- a/Showcase/portal-user-examples/webContent/layouts/restricted/CaseMapOverviewTemplate.xhtml
+++ b/Showcase/portal-user-examples/webContent/layouts/restricted/CaseMapOverviewTemplate.xhtml
@@ -33,7 +33,7 @@
                     <div class="ui-g-12 height-100 case-map-stage">
                       <div class="ui-g-12 #{stageStatus.first?'':'line-left'} #{stageStatus.last?'':'line-right'}">
                         <div class="square center card">
-                          <i class="#{caseMapDetailBean.getIconOfStage(caseMapDetail, stage)} case-stage-icon" />
+                          <i class="#{exampleCaseMapDetailBean.getIconOfStage(caseMapDetail, stage)} case-stage-icon" />
                         </div>
                       </div>
                       <div class="ui-g-12 case-stage">
@@ -47,7 +47,7 @@
                       <div class="card ui-g-12 case-stage-detail">
 
                         <!-- PROCESS -->
-                        <ui:repeat var="desc" value="#{caseMapDetailBean.getProcessOfStage(caseMapDetail, stage)}">
+                        <ui:repeat var="desc" value="#{exampleCaseMapDetailBean.getProcessOfStage(caseMapDetail, stage)}">
                           <div class="card ui-g-12 case-stage-process">
                             <div class="ui-g-11">
                               <h:outputText value="#{desc}" styleClass="case-stage-text" />
@@ -57,7 +57,7 @@
                             </div>
                             <hr />
                             <div class="ui-g-12"
-                              jsf:rendered="#{caseMapDetailBean.renderPreCondition(caseMapDetail, desc)}">
+                              jsf:rendered="#{exampleCaseMapDetailBean.renderPreCondition(caseMapDetail, desc)}">
                               <i class="ti ti-diamond precondition-icon"
                                 title="#{ivy.cms.co('/Labels/HasPrecondition')}" />
                             </div>
@@ -65,10 +65,10 @@
                         </ui:repeat>
 
                         <!-- SIDE STEP -->
-                        <div jsf:rendered="#{not empty caseMapDetailBean.getSideStepOfStage(caseMapDetail, stage)}">
+                        <div jsf:rendered="#{not empty exampleCaseMapDetailBean.getSideStepOfStage(caseMapDetail, stage)}">
                           <hr />
                         </div>
-                        <ui:repeat var="desc" value="#{caseMapDetailBean.getSideStepOfStage(caseMapDetail, stage)}">
+                        <ui:repeat var="desc" value="#{exampleCaseMapDetailBean.getSideStepOfStage(caseMapDetail, stage)}">
                           <div class="card ui-g-12 case-stage-process">
                             <div class="ui-g-11">
                               <h:outputText value="#{desc}" styleClass="case-stage-text" />
@@ -78,7 +78,7 @@
                             </div>
                             <hr />
                             <div class="ui-g-12"
-                              jsf:rendered="#{caseMapDetailBean.renderPreCondition(caseMapDetail, desc)}">
+                              jsf:rendered="#{exampleCaseMapDetailBean.renderPreCondition(caseMapDetail, desc)}">
                               <span class="ti ti-diamond precondition-icon"
                                 title="#{ivy.cms.co('/Labels/HasPrecondition')}" />
                             </div>


### PR DESCRIPTION
With the update to jakarta and cdi it is no longer possible to have the same bean (same name) twice in the same application. For the portal this makes no change, but if someone has the portal and the portal-user-examples deployed to the same app, this app is no longer able to start. And also if you have the portal repo open in vscode it can no longer start the app on the engine.

So this pr is a preparation for the update to the jakarta / cdi beans.