### PR TITLE
Revert "Update dependency com.codeborne:selenide-proxy to v7.17.0 (master)"

### DIFF
--- a/AxonIvyPortal/portal-selenium-test/pom.xml
+++ b/AxonIvyPortal/portal-selenium-test/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.codeborne</groupId>
       <artifactId>selenide-proxy</artifactId>
-      <version>7.17.0</version>
+      <version>7.9.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Reverts axonivy-market/portal#3556
Reverts selenide-proxy 7.17.0 → 7.9.2. That version pulls in selenium-java 4.46.0, which is incompatible with selenide-core 7.16.2 (still pinned by ivy-api-bom), causing NoSuchMethodError: BiDi.addListener on all local Selenium tests.

Next time Renovate opens this bump again, close it, don't merge until ivy-api-bom updates its managed selenide version to match.