### PR TITLE
IVYPORTAL-20805 Allow hidden roles to be selected as parent roles

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/RoleManagementBean.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/bean/RoleManagementBean.java
@@ -265,6 +265,18 @@ public class RoleManagementBean implements Serializable {
     this.selectedParentRole = selectedParentRole;
   }
 
+  /**
+   * Parent role candidates must include hidden roles (e.g. AXONIVY_PORTAL_ADMIN), since Role Management
+   * is an admin tool and shouldn't hide roles meant to be hidden only from normal end-user UI.
+   */
+  public List<RoleDTO> completeParentRole(String query) {
+    List<RoleDTO> roles = RoleUtils.filterRoles(RoleUtils.getAllRoles(), query).stream()
+        .map(RoleDTO::new)
+        .collect(Collectors.toList());
+    roles.sort((first, second) -> first.getDisplayName().compareToIgnoreCase(second.getDisplayName()));
+    return roles;
+  }
+
   public boolean isCreationMode() {
     return isCreationMode;
   }

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/RoleManagement/RoleManagement.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/RoleManagement/RoleManagement.xhtml
@@ -179,6 +179,7 @@
           <ic:com.axonivy.portal.components.RoleSelection id="parent-role"
             componentId="parent-role-selection"
             selectedRole="#{roleManagementBean.selectedParentRole}"
+            completeMethod="#{roleManagementBean.completeParentRole}"
             isRequired="#{roleManagementBean.canMoveRole}"
             isDisabled="#{!roleManagementBean.canMoveRole}"
             label="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/components/RoleManagement/ParentRole')}"


### PR DESCRIPTION
Close #3565
 ### Description

  Allows hidden roles (e.g.,  `AXONIVY_PORTAL_ADMIN` ) to be selected as a parent role in the Role Management administrative screen.

  ### Why

  The parent role selection component reused the generic  RoleSelection  picker which filters out hidden roles. Since Role Management is an administrative tool, admins should be able to view and select all roles, including hidden ones, when defining parent-child relationships.