### PR TITLE
Improve global search

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/CaseSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/CaseSearchCriteria.java
@@ -119,14 +119,12 @@ public class CaseSearchCriteria {
 
     try {
       long idKeyword = Long.parseLong(keyword.trim());
-      String containingIdKeyword = String.format("%%%d%%", idKeyword);
-      filterByKeywordQuery.where().or().caseId().isLike(containingIdKeyword);
+      // Numeric keyword: match the case id via an equality (primary-key) lookup instead of
+      // CAST(CaseId) LIKE '%n%', which casts the PK to text and defeats the PK index.
+      filterByKeywordQuery.where().or().caseId().isEqual(idKeyword);
     } catch (NumberFormatException e) {
-      if (isGlobalSearch()) {
-        String containingIdKeyword = String.format("%%%d%%", -1);
-        filterByKeywordQuery.where().or().caseId().isLike(containingIdKeyword);
-      }
-      // do nothing
+      // Non-numeric keyword: no case-id predicate. (Previously added a guaranteed-empty
+      // caseId LIKE '%-1%' under global search, which forced a full CAST(CaseId) scan.)
     }
     return filterByKeywordQuery;
   }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
@@ -160,13 +160,12 @@ public class TaskSearchCriteria {
 
     try {
         long idKeyword = Long.parseLong(keyword.trim());
-        String containingIdKeyword = String.format("%%%d%%", idKeyword);
-        filterByKeywordQuery.where().or().taskId().isLike(containingIdKeyword);
+        // Numeric keyword: match the task id via an equality (primary-key) lookup instead of
+        // CAST(TaskId) LIKE '%n%', which casts the PK to text and defeats the PK index.
+        filterByKeywordQuery.where().or().taskId().isEqual(idKeyword);
       } catch (NumberFormatException e) {
-        if (isGlobalSearch()) {
-          String containingIdKeyword = String.format("%%%d%%", -1);
-          filterByKeywordQuery.where().or().taskId().isLike(containingIdKeyword);
-        }
+        // Non-numeric keyword: no task-id predicate. (Previously added a guaranteed-empty
+        // taskId LIKE '%-1%' under global search, which forced a full CAST(TaskId) scan.)
       }
     return filterByKeywordQuery;
   }

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
@@ -65,6 +65,8 @@ public class GlobalSearchService {
   private TaskSearchCriteria buildTaskCriteria(SearchPayload payload) {
     TaskSearchCriteria criteria = new TaskSearchCriteria();
     criteria.setKeyword(payload.getQuery());
+    // Honor SEARCH_SCOPE_BY_TASK_FIELDS on this REST path (see buildCaseCriteria).
+    criteria.setGlobalSearch(true);
     criteria.setSortField(TaskSortField.EXPIRY_TIME.toString());
     criteria.setSortDescending(true);
     criteria.setTaskAssigneeType(TaskAssigneeType.ALL);
@@ -79,6 +81,10 @@ public class GlobalSearchService {
   private CaseSearchCriteria buildCaseCriteria(SearchPayload payload) {
     CaseSearchCriteria criteria = new CaseSearchCriteria();
     criteria.setKeyword(payload.getQuery());
+    // Honor SEARCH_SCOPE_BY_CASE_FIELDS on this REST path: queryForKeyword only restricts the
+    // scanned fields when isGlobalSearch is true. Without this the config is ignored and NAME +
+    // DESCRIPTION + CUSTOM always run (the CUSTOM anyStringField scan is the dominant cost).
+    criteria.setGlobalSearch(true);
     criteria.setSearchScopeCaseFields(getSearchScopeCaseFields());
     criteria.setBusinessCase(true);
     criteria.setIncludedStates(new ArrayList<>(Arrays.asList(CaseState.CREATED, CaseState.RUNNING, CaseState.DONE)));
@@ -179,7 +185,12 @@ public class GlobalSearchService {
       }
       return searchScopeCaseFields;
     }
-    return List.of(SearchScopeCaseField.NAME, SearchScopeCaseField.DESCRIPTION, SearchScopeCaseField.CUSTOM);
+    // Default excludes CUSTOM: searching custom fields runs
+    // customField().anyStringField().isLikeIgnoreCase('%kw%'), a full scan of the entire
+    // IWA_CaseCustomStringField table - the dominant cost of the slow global-search-cases query.
+    // Admins who need custom-field search can re-enable it via SEARCH_SCOPE_BY_CASE_FIELDS
+    // (e.g. NAME,DESCRIPTION,CUSTOM).
+    return List.of(SearchScopeCaseField.NAME, SearchScopeCaseField.DESCRIPTION);
   }
 
   private String buildCaseDataLink(ICase caze, boolean canAccessBusinessDetails) {


### PR DESCRIPTION
GlobalSearchService.buildCaseCriteria/buildTaskCriteria never set isGlobalSearch, so SEARCH_SCOPE_BY_CASE_FIELDS/BY_TASK_FIELDS were ignored on this REST path and the CUSTOM case-field predicate (a full scan of IWA_CaseCustomStringField) always ran alongside NAME/DESCRIPTION. 
Numeric keyword lookups now use caseId()/taskId() .isEqual() instead of CAST(...) LIKE '%n%', which defeated the PK index;  this also removes the resulting dead caseId/taskId LIKE '%-1%' branch for non-numeric input.

Default case search scope now excludes CUSTOM (NAME, DESCRIPTION only), which is the change that removes the dominant cost. Admins who rely on custom-field search can restore it via SEARCH_SCOPE_BY_CASE_FIELDS=NAME,DESCRIPTION,CUSTOM.