### PR TITLE
IVYPORTAL-20878 Global search scopes of not correct in query

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/CaseSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/CaseSearchCriteria.java
@@ -139,8 +139,9 @@ public class CaseSearchCriteria {
       filterByKeywordQuery.where().or().caseId().isLike(containingIdKeyword);
     } catch (NumberFormatException e) {
       if (isGlobalSearch()) {
-        String containingIdKeyword = String.format("%%%d%%", -1);
-        filterByKeywordQuery.where().or().caseId().isLike(containingIdKeyword);
+        // Never leave the keyword query empty (IVYPORTAL-14457). No case id is negative,
+        // so this matches nothing; isEqual avoids a CAST on every row.
+        filterByKeywordQuery.where().or().caseId().isEqual(-1L);
       }
       // do nothing
     }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/CaseSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/CaseSearchCriteria.java
@@ -139,8 +139,6 @@ public class CaseSearchCriteria {
       filterByKeywordQuery.where().or().caseId().isLike(containingIdKeyword);
     } catch (NumberFormatException e) {
       if (isGlobalSearch()) {
-        // Never leave the keyword query empty (IVYPORTAL-14457). No case id is negative,
-        // so this matches nothing; isEqual avoids a CAST on every row.
         filterByKeywordQuery.where().or().caseId().isEqual(-1L);
       }
       // do nothing

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
@@ -184,8 +184,6 @@ public class TaskSearchCriteria {
         filterByKeywordQuery.where().or().taskId().isLike(containingIdKeyword);
       } catch (NumberFormatException e) {
         if (isGlobalSearch()) {
-          // Never leave the keyword query empty (IVYPORTAL-14457). No task id is negative,
-          // so this matches nothing; isEqual avoids a CAST on every row.
           filterByKeywordQuery.where().or().taskId().isEqual(-1L);
         }
       }

--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/ivydata/searchcriteria/TaskSearchCriteria.java
@@ -184,8 +184,9 @@ public class TaskSearchCriteria {
         filterByKeywordQuery.where().or().taskId().isLike(containingIdKeyword);
       } catch (NumberFormatException e) {
         if (isGlobalSearch()) {
-          String containingIdKeyword = String.format("%%%d%%", -1);
-          filterByKeywordQuery.where().or().taskId().isLike(containingIdKeyword);
+          // Never leave the keyword query empty (IVYPORTAL-14457). No task id is negative,
+          // so this matches nothing; isEqual avoids a CAST on every row.
+          filterByKeywordQuery.where().or().taskId().isEqual(-1L);
         }
       }
     return filterByKeywordQuery;

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
@@ -89,8 +89,6 @@ public class GlobalSearchService {
     boolean isAdminQuery = PermissionUtils.checkReadAllTasksPermission();
     criteria.setAdminQuery(isAdminQuery);
     criteria.extendStatesQueryByPermission(isAdminQuery);
-    boolean hasReadAllTasksPermisson = PermissionUtils.checkReadAllTasksPermission();
-    criteria.setAdminQuery(hasReadAllTasksPermisson);
     return criteria;
   }
 

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
@@ -72,7 +72,6 @@ public class GlobalSearchService {
     boolean isAdminQuery = PermissionUtils.checkReadAllTasksPermission();
     criteria.setAdminQuery(isAdminQuery);
     criteria.extendStatesQueryByPermission(isAdminQuery);
-    // Required for queryForKeyword() to honor SEARCH_SCOPE_BY_TASK_FIELDS instead of searching every field.
     criteria.setGlobalSearch(true);
     criteria.setSearchScopeTaskFields(getSearchScopeTaskFields());
     return criteria;
@@ -81,7 +80,6 @@ public class GlobalSearchService {
   private CaseSearchCriteria buildCaseCriteria(SearchPayload payload) {
     CaseSearchCriteria criteria = new CaseSearchCriteria();
     criteria.setKeyword(payload.getQuery());
-    // Required for queryForKeyword() to honor SEARCH_SCOPE_BY_CASE_FIELDS instead of searching every field.
     criteria.setGlobalSearch(true);
     criteria.setSearchScopeCaseFields(getSearchScopeCaseFields());
     criteria.setBusinessCase(true);

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
@@ -72,6 +72,7 @@ public class GlobalSearchService {
     boolean isAdminQuery = PermissionUtils.checkReadAllTasksPermission();
     criteria.setAdminQuery(isAdminQuery);
     criteria.extendStatesQueryByPermission(isAdminQuery);
+    // Required for queryForKeyword() to honor SEARCH_SCOPE_BY_TASK_FIELDS instead of searching every field.
     criteria.setGlobalSearch(true);
     criteria.setSearchScopeTaskFields(getSearchScopeTaskFields());
     return criteria;
@@ -80,6 +81,7 @@ public class GlobalSearchService {
   private CaseSearchCriteria buildCaseCriteria(SearchPayload payload) {
     CaseSearchCriteria criteria = new CaseSearchCriteria();
     criteria.setKeyword(payload.getQuery());
+    // Required for queryForKeyword() to honor SEARCH_SCOPE_BY_CASE_FIELDS instead of searching every field.
     criteria.setGlobalSearch(true);
     criteria.setSearchScopeCaseFields(getSearchScopeCaseFields());
     criteria.setBusinessCase(true);

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
@@ -72,6 +72,7 @@ public class GlobalSearchService {
     boolean isAdminQuery = PermissionUtils.checkReadAllTasksPermission();
     criteria.setAdminQuery(isAdminQuery);
     criteria.extendStatesQueryByPermission(isAdminQuery);
+    criteria.setGlobalSearch(true);
     criteria.setSearchScopeTaskFields(getSearchScopeTaskFields());
     return criteria;
   }
@@ -79,6 +80,7 @@ public class GlobalSearchService {
   private CaseSearchCriteria buildCaseCriteria(SearchPayload payload) {
     CaseSearchCriteria criteria = new CaseSearchCriteria();
     criteria.setKeyword(payload.getQuery());
+    criteria.setGlobalSearch(true);
     criteria.setSearchScopeCaseFields(getSearchScopeCaseFields());
     criteria.setBusinessCase(true);
     criteria.setIncludedStates(new ArrayList<>(Arrays.asList(CaseState.CREATED, CaseState.RUNNING, CaseState.DONE)));


### PR DESCRIPTION
## Summary
- `GlobalSearchService.buildTaskCriteria`/`buildCaseCriteria` now call `criteria.setGlobalSearch(true)`, so the `SEARCH_SCOPE_BY_TASK_FIELDS`/`SEARCH_SCOPE_BY_CASE_FIELDS` admin variables are actually honored on the `/api/global-search` REST path (used by the quick-search overlay panel). Previously this flag was never set, so every field (name, description, and custom fields for cases) was always searched regardless of what the admin configured. `SearchResultsDataModel` (the full search-results page) already set this flag; the REST path was simply missing it.
- Follow-on to the above: setting the flag also activates the existing IVYPORTAL-14457 empty-scope guard on this hot path for every non-numeric keyword. That guard used `caseId/taskId LIKE '%-1%'`, which forces a CAST of the id column on every row; it now uses `isEqual(-1L)`. Same match-nothing result (no id is negative), without the per-row CAST. The numeric-keyword branch is a user-visible contains-match and is deliberately left unchanged.