### PR TITLE
IVYPORTAL-20904 Task permission is used for case on global search

### DIFF
--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
@@ -84,7 +84,7 @@ public class GlobalSearchService {
     criteria.setSearchScopeCaseFields(getSearchScopeCaseFields());
     criteria.setBusinessCase(true);
     criteria.setIncludedStates(new ArrayList<>(Arrays.asList(CaseState.CREATED, CaseState.RUNNING, CaseState.DONE)));
-    boolean isAdminQuery = PermissionUtils.checkReadAllTasksPermission();
+    boolean isAdminQuery = PermissionUtils.checkReadAllCasesPermission();
     criteria.setAdminQuery(isAdminQuery);
     criteria.extendStatesQueryByPermission(isAdminQuery);
     return criteria;


### PR DESCRIPTION
## Summary
- `GlobalSearchService.buildCaseCriteria` decided whether the **case** query is an unrestricted admin query from `PermissionUtils.checkReadAllTasksPermission()` (`IPermission.TASK_READ_ALL`) — the *task* permission — instead of `checkReadAllCasesPermission()` (`IPermission.CASE_READ_ALL`). One-word fix; `buildTaskCriteria` is correct as-is and keeps the task permission.
