### PR TITLE
IVYPORTAL-20909: Could not delete a saved filter with comma

### DIFF
--- a/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
@@ -317,7 +317,7 @@
               <div class="ui-g-12">
                 <p:dataTable id="quick-filter-table" value="#{dashboardBean.widgetFilters}" var="quickFilter"
                   widgetVar="quick-filter-table" scrollHeight="300" scrollable="true" reflow="true"
-                  selection="#{dashboardBean.deleteFilters}" rowKey="#{quickFilter.name}"
+                  selection="#{dashboardBean.deleteFilters}" rowKey="#{quickFilter.id}"
                   emptyMessage="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/EmptyFilterMessage')}" lazy="false">
                   
                   <p:column selectionMode="multiple" styleClass="saved-filter-selection-column text-center" width="20"/>


### PR DESCRIPTION
PrimeFaces p:dataTable fails to select items when the rowKey contains a comma because the component internally splits selection strings and keys using commas.