### PR TITLE
IVYPORTAL-20916 Scope case details opened from task details

### DIFF
--- a/AxonIvyPortal/portal/processes/Functional Processes/Navigator.p.json
+++ b/AxonIvyPortal/portal/processes/Functional Processes/Navigator.p.json
@@ -19,7 +19,7 @@
         }
       },
       "visual" : {
-        "at" : { "x" : 1888, "y" : 1480 }
+        "at" : { "x" : 1888, "y" : 1544 }
       },
       "connect" : [
         { "id" : "f2", "to" : "f1" }
@@ -28,7 +28,7 @@
       "id" : "f1",
       "type" : "CallSubEnd",
       "visual" : {
-        "at" : { "x" : 1888, "y" : 1592 }
+        "at" : { "x" : 1888, "y" : 1656 }
       }
     }, {
       "id" : "f0",
@@ -59,19 +59,42 @@
       "config" : {
         "output" : {
           "code" : [
-            "import ch.ivyteam.ivy.workflow.query.CaseQuery;",
-            "import ch.ivyteam.ivy.workflow.ICase;",
+            "import ch.ivy.addon.portalkit.ivydata.service.impl.CaseService;",
             "",
-            "out.caze = ivy.wf.getCaseQueryExecutor().createCaseQuery().where().uuid().isEqual(in.caseId.uuid()).executor().firstResult() as ICase;"
+            "// Only resolve cases the current user is allowed to see, same rule as the case list",
+            "out.caze = CaseService.newInstance().findCaseByUUID(in.caseId.uuid());"
           ]
-        },
-        "sudo" : true
+        }
       },
       "visual" : {
         "at" : { "x" : 1888, "y" : 1360 }
       },
       "connect" : [
-        { "id" : "f6", "to" : "f5" }
+        { "id" : "f6", "to" : "f100" }
+      ]
+    }, {
+      "id" : "f100",
+      "type" : "Alternative",
+      "name" : "Case accessible?",
+      "config" : {
+        "conditions" : {
+          "f101" : "in.caze != null"
+        }
+      },
+      "visual" : {
+        "at" : { "x" : 1888, "y" : 1456 },
+        "labelOffset" : { "x" : 72, "y" : -32 }
+      },
+      "connect" : [
+        { "id" : "f101", "to" : "f5", "label" : {
+            "name" : "Yes",
+            "offset" : { "x" : -23, "y" : -7 }
+          } },
+        { "id" : "f102", "to" : "f1", "via" : [ { "x" : 1976, "y" : 1456 }, { "x" : 1976, "y" : 1656 } ], "label" : {
+            "name" : "No",
+            "segment" : 2.16,
+            "offset" : { "x" : -36, "y" : -186 }
+          } }
       ]
     }, {
       "id" : "f54",

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskItemGeneralInfo/TaskItemGeneralInfo.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskItemGeneralInfo/TaskItemGeneralInfo.xhtml
@@ -325,7 +325,8 @@
             value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/taskDetails/businessCase')}" />
         </div>
         <div class="ui-xl-10 ui-lg-8 ui-md-8 ui-sm-8 ui-g-10 u-no-padding-left u-truncate-text">
-          <p:commandLink id="related-case" styleClass="task-business-case" disabled="#{cc.attrs.readOnly}"
+          <p:commandLink id="related-case" styleClass="task-business-case"
+            disabled="#{cc.attrs.readOnly or not caseWidgetBean.isCaseFound(task.getCase().getBusinessCase())}"
             value="#{taskBean.displayCaseName(task)}" ariaLabel="#{taskBean.displayCaseName(task)}"
             actionListener="#{logic.navigateToRelatedCase(task.getCase().getBusinessCase())}">
           </p:commandLink>
@@ -343,7 +344,7 @@
             ariaLabel="#{taskBean.getTechnicalCaseDisplayName(task)}"
             actionListener="#{logic.navigateToRelatedCase(task.getCase())}"
             rendered="#{task.getCase().getId() != task.getCase().getBusinessCase().getId()}"
-            disabled="#{cc.attrs.readOnly}">
+            disabled="#{cc.attrs.readOnly or not caseWidgetBean.isCaseFound(task.getCase())}">
           </p:commandLink>
         </div>
       </h:panelGroup>


### PR DESCRIPTION
Fix can access a case details via task details page, and disable the case links when the case is not accessible.

Backport of the master fix. Adapted for the 12.0 layout: the composite lives under src_hd/ instead of dialog/, the process under processes/ instead of process/, and the Navigator diagram nodes below the new alternative were shifted to the 12.0 coordinates.