### PR TITLE
IVYPORTAL-20986 Global search and full results page not aligned

### DIFF
--- a/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/SearchResultsDataModel.java
+++ b/AxonIvyPortal/portal/src/ch/ivy/addon/portalkit/datamodel/SearchResultsDataModel.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.axonivy.portal.enums.SearchScopeCaseField;
 import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.enums.GlobalSearchScopeCategory;
+import com.axonivy.portal.util.SearchScopeUtils;
 
 import ch.ivy.addon.portalkit.enums.GlobalVariable;
 import ch.ivy.addon.portalkit.enums.TaskAssigneeType;
@@ -43,37 +44,9 @@ public class SearchResultsDataModel implements Serializable {
     caseDataModel = initCaseDataModel();
     caseDataModel.setIsAdminQuery(hasReadAllCasesPermission);
 
-    initSearchScopeTaskFields();
-    initSearchScopeCaseFields();
+    searchScopeTaskFields = SearchScopeUtils.getSearchScopeTaskFields();
+    searchScopeCaseFields = SearchScopeUtils.getSearchScopeCaseFields();
     initGlobalSearchScopeCategories();
-  }
-
-  private void initSearchScopeTaskFields() {
-    String searchScopeTaskFieldsString = Ivy.var().get(GlobalVariable.SEARCH_SCOPE_BY_TASK_FIELDS.getKey());
-    if (StringUtils.isNotBlank(searchScopeTaskFieldsString)) {
-      searchScopeTaskFields = new ArrayList<>();
-      String[] fieldArray = searchScopeTaskFieldsString.split(",");
-      for(String field : fieldArray) {
-        SearchScopeTaskField fieldEnum = SearchScopeTaskField.valueOf(field.toUpperCase());
-        if (fieldEnum != null) {
-          searchScopeTaskFields.add(fieldEnum);
-        }
-      }
-    }
-  }
-
-  private void initSearchScopeCaseFields() {
-    String searchScopeCaseFieldsString = Ivy.var().get(GlobalVariable.SEARCH_SCOPE_BY_CASE_FIELDS.getKey());
-    if (StringUtils.isNotBlank(searchScopeCaseFieldsString)) {
-      searchScopeCaseFields = new ArrayList<>();
-      String[] fieldArray = searchScopeCaseFieldsString.split(",");
-      for(String field : fieldArray) {
-        SearchScopeCaseField fieldEnum = SearchScopeCaseField.valueOf(field.toUpperCase());
-        if (fieldEnum != null) {
-          searchScopeCaseFields.add(fieldEnum);
-        }
-      }
-    }
   }
 
   private void initGlobalSearchScopeCategories() {
@@ -115,13 +88,8 @@ public class SearchResultsDataModel implements Serializable {
     this.taskDataModel.getCriteria().setGlobalSearch(true);
     this.caseDataModel.getCriteria().setGlobalSearch(true);
 
-    if (CollectionUtils.isNotEmpty(searchScopeTaskFields)) {
-      this.taskDataModel.getCriteria().setSearchScopeTaskFields(searchScopeTaskFields);
-    }
-
-    if (CollectionUtils.isNotEmpty(searchScopeCaseFields)) {
-      this.caseDataModel.getCriteria().setSearchScopeCaseFields(searchScopeCaseFields);
-    }
+    this.taskDataModel.getCriteria().setSearchScopeTaskFields(searchScopeTaskFields);
+    this.caseDataModel.getCriteria().setSearchScopeCaseFields(searchScopeCaseFields);
 
     if (CollectionUtils.isNotEmpty(globalSearchScopeCategories)) {
       this.caseDataModel.getCriteria().setGlobalSearchScope(globalSearchScopeCategories.contains(GlobalSearchScopeCategory.CASES));

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/service/GlobalSearchService.java
@@ -10,8 +10,6 @@ import org.apache.commons.lang3.StringUtils;
 import com.axonivy.portal.components.publicapi.PortalNavigatorAPI;
 import com.axonivy.portal.components.service.impl.ProcessService;
 import com.axonivy.portal.enums.GlobalSearchScopeCategory;
-import com.axonivy.portal.enums.SearchScopeCaseField;
-import com.axonivy.portal.enums.SearchScopeTaskField;
 import com.axonivy.portal.payload.SearchPayload;
 import com.axonivy.portal.response.CaseData;
 import com.axonivy.portal.response.GlobalSearchResponse;
@@ -19,6 +17,7 @@ import com.axonivy.portal.response.ProcessData;
 import com.axonivy.portal.response.TaskData;
 import com.axonivy.portal.util.BusinessDetailsUtils;
 import com.axonivy.portal.util.CaseBehaviorUtils;
+import com.axonivy.portal.util.SearchScopeUtils;
 
 import ch.ivy.addon.portalkit.enums.GlobalVariable;
 import ch.ivy.addon.portalkit.enums.TaskAssigneeType;
@@ -73,7 +72,7 @@ public class GlobalSearchService {
     criteria.setAdminQuery(isAdminQuery);
     criteria.extendStatesQueryByPermission(isAdminQuery);
     criteria.setGlobalSearch(true);
-    criteria.setSearchScopeTaskFields(getSearchScopeTaskFields());
+    criteria.setSearchScopeTaskFields(SearchScopeUtils.getSearchScopeTaskFields());
     return criteria;
   }
 
@@ -81,7 +80,7 @@ public class GlobalSearchService {
     CaseSearchCriteria criteria = new CaseSearchCriteria();
     criteria.setKeyword(payload.getQuery());
     criteria.setGlobalSearch(true);
-    criteria.setSearchScopeCaseFields(getSearchScopeCaseFields());
+    criteria.setSearchScopeCaseFields(SearchScopeUtils.getSearchScopeCaseFields());
     criteria.setBusinessCase(true);
     criteria.setIncludedStates(new ArrayList<>(Arrays.asList(CaseState.CREATED, CaseState.RUNNING, CaseState.DONE)));
     boolean isAdminQuery = PermissionUtils.checkReadAllTasksPermission();
@@ -152,38 +151,6 @@ public class GlobalSearchService {
     return isShowFullTaskList && isHasSearchScope;
   }
   
-  private List<SearchScopeTaskField> getSearchScopeTaskFields() {
-    String searchScopeTaskFieldsString = Ivy.var().get(GlobalVariable.SEARCH_SCOPE_BY_TASK_FIELDS.getKey());
-    if (StringUtils.isNotBlank(searchScopeTaskFieldsString)) {
-      List<SearchScopeTaskField> searchScopeTaskFields = new ArrayList<>();
-      String[] fieldArray = searchScopeTaskFieldsString.split(",");
-      for (String field : fieldArray) {
-        SearchScopeTaskField fieldEnum = SearchScopeTaskField.valueOf(field.toUpperCase());
-        if (fieldEnum != null) {
-          searchScopeTaskFields.add(fieldEnum);
-        }
-      }
-      return searchScopeTaskFields;
-    }
-    return List.of(SearchScopeTaskField.NAME, SearchScopeTaskField.DESCRIPTION);
-  }
-
-  private List<SearchScopeCaseField> getSearchScopeCaseFields() {
-    String searchScopeCaseFieldsString = Ivy.var().get(GlobalVariable.SEARCH_SCOPE_BY_CASE_FIELDS.getKey());
-    if (StringUtils.isNotBlank(searchScopeCaseFieldsString)) {
-      List<SearchScopeCaseField> searchScopeCaseFields = new ArrayList<>();
-      String[] fieldArray = searchScopeCaseFieldsString.split(",");
-      for (String field : fieldArray) {
-        SearchScopeCaseField fieldEnum = SearchScopeCaseField.valueOf(field.toUpperCase());
-        if (fieldEnum != null) {
-          searchScopeCaseFields.add(fieldEnum);
-        }
-      }
-      return searchScopeCaseFields;
-    }
-    return List.of(SearchScopeCaseField.NAME, SearchScopeCaseField.DESCRIPTION, SearchScopeCaseField.CUSTOM);
-  }
-
   private String buildCaseDataLink(ICase caze, boolean canAccessBusinessDetails) {
     if (canAccessBusinessDetails) {
       return BusinessDetailsUtils.getAdditionalCaseDetailsPageUri(caze);

--- a/AxonIvyPortal/portal/src/com/axonivy/portal/util/SearchScopeUtils.java
+++ b/AxonIvyPortal/portal/src/com/axonivy/portal/util/SearchScopeUtils.java
@@ -1,0 +1,47 @@
+package com.axonivy.portal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.axonivy.portal.enums.SearchScopeCaseField;
+import com.axonivy.portal.enums.SearchScopeTaskField;
+
+import ch.ivy.addon.portalkit.enums.GlobalVariable;
+import ch.ivyteam.ivy.environment.Ivy;
+
+/**
+ * Resolves the global search scope variables for every caller, so that the quick search
+ * overlay and the full search results page cannot disagree on which fields are searched.
+ * <p>
+ * The scope names the fields searched <em>beside</em> the task or case id, so an empty
+ * scope is a valid configuration that means "match the id only". It is deliberately not
+ * substituted by a default; the shipped defaults live in {@code variables.yaml}.
+ */
+public class SearchScopeUtils {
+
+  public static List<SearchScopeTaskField> getSearchScopeTaskFields() {
+    return getSearchScopeFields(GlobalVariable.SEARCH_SCOPE_BY_TASK_FIELDS, SearchScopeTaskField.class);
+  }
+
+  public static List<SearchScopeCaseField> getSearchScopeCaseFields() {
+    return getSearchScopeFields(GlobalVariable.SEARCH_SCOPE_BY_CASE_FIELDS, SearchScopeCaseField.class);
+  }
+
+  private static <E extends Enum<E>> List<E> getSearchScopeFields(GlobalVariable variable, Class<E> fieldType) {
+    List<E> fields = new ArrayList<>();
+    String configuredFields = Ivy.var().get(variable.getKey());
+    if (StringUtils.isBlank(configuredFields)) {
+      return fields;
+    }
+    for (String field : configuredFields.split(",")) {
+      String fieldName = field.trim().toUpperCase();
+      if (StringUtils.isNotEmpty(fieldName)) {
+        fields.add(Enum.valueOf(fieldType, fieldName));
+      }
+    }
+    return fields;
+  }
+
+}


### PR DESCRIPTION
With `Portal.SearchScope.ByTaskFields` (or `ByCaseFields`) saved empty, the quick search overlay and the full results page disagree completely.

`Portal.SearchScope.ByTaskFields` was parsed in two places, and the two copies handled a blank value differently:

| | blank value | result for keyword `a` |
|---|---|---|
| `GlobalSearchService.getSearchScopeTaskFields()` | falls through to a hardcoded `List.of(NAME, DESCRIPTION)` | overlay searches every field, **finds everything** |
| `SearchResultsDataModel.initSearchScopeTaskFields()` | `isNotBlank` check with no `else`, field stays `null` | no field predicate, only the `taskId().isEqual(-1L)` guard fires, **finds nothing** |

Same variable, same value, opposite behaviour.

## Fix

Both read paths now go through one resolver, `SearchScopeUtils`, which returns an empty list for a blank value. The two duplicated parse loops are gone, so the paths cannot drift again.