### PR TITLE
IVYPORTAL-20988 Improve ARIA heading native semantics in Portal

### DIFF
--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/ProcessInformationPage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/ProcessInformationPage.java
@@ -39,7 +39,7 @@ public class ProcessInformationPage extends TemplatePage {
 
   public String getProcessName() {
     waitForElementDisplayed(By.cssSelector("[id$='header']"), true);
-    return findElementByCssSelector("[id='header'] > h2 ").getText();
+    return findElementByCssSelector("[id='header'] > p").getText();
   }
 
   public String getProcessDescription() {

--- a/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/UserProfilePage.java
+++ b/AxonIvyPortal/portal-selenium-test/src_test/com/axonivy/portal/selenium/page/UserProfilePage.java
@@ -78,7 +78,7 @@ public class UserProfilePage extends TemplatePage {
   }
 
   public String getLanguageSettingTitle() {
-    return findElementByCssSelector("h5[id$='language-setting-title']").getText();
+    return findElementByCssSelector("[id$='language-setting-title']").getText();
   }
 
   public void changeNewDashboardPageToCase() {

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/component/ProcessInformation/ProcessInformation.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/component/ProcessInformation/ProcessInformation.xhtml
@@ -17,7 +17,7 @@
         <i id="icon" class="#{iconSelectionBean.generateIconWithFontFamily(data.selectedProcess.getIcon())} process-info-icon" />
       </div>
       <div id="header" class="ui-g-11 ui-xl-11 ui-lg-11 ui-md-10 ui-sm-9 text-left header-process-name">
-        <h2>#{data.selectedProcess.processName}</h2>
+        <p class="text-style-h2">#{data.selectedProcess.processName}</p>
       </div>
       <div class="ui-g-12 process-info-description" jsf:rendered="#{data.selectedProcess.description ne ''}">
         <h:outputText id="process-description" value="#{data.selectedProcess.description}" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/error/ErrorPage/ErrorPage.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/error/ErrorPage/ErrorPage.xhtml
@@ -15,12 +15,12 @@
       <div class="error-container container">
         <div class="message card">
           <ui:fragment rendered="#{data.errorCode eq '404'}">
-            <div class="message-header"><h3>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/errorPage/404')}</h3></div>
+            <div class="message-header"><p class="text-style-h3">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/errorPage/404')}</p></div>
             <div class="message-container"><p>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/errorPage/404Message')}</p></div>
           </ui:fragment>
 
           <ui:fragment rendered="#{data.errorCode eq '500'}">
-            <div class="message-header"><h3>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/errorPage/500')}</h3></div>
+            <div class="message-header"><p class="text-style-h3">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/errorPage/500')}</p></div>
             <div class="message-container"><p>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/errorPage/500Message')}</p></div>
           </ui:fragment>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/PasswordReset/PasswordReset.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/PasswordReset/PasswordReset.xhtml
@@ -63,8 +63,8 @@
         </div>
       </div>
       <div class="login-footer">
-        <h4>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/AxonIvyPortal')}</h4>
-        <h6>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/Copyright')}</h6>
+        <p class="text-style-h4">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/AxonIvyPortal')}</p>
+        <p class="text-style-h6">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/Copyright')}</p>
       </div>
     </div>
   </div>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardConfiguration/PortalDashboardConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/PortalDashboardConfiguration/PortalDashboardConfiguration.xhtml
@@ -20,7 +20,7 @@
             <c:set var="selectedDashboardTypeStyleClass" value="#{isPublicDashboard ? 'js-public-dashboard':'js-private-dashboard'}" scope="request"/>
             <div class="ui-g-12 u-no-padding-top u-no-padding-bottom">
               <div class="ui-g-12 dashboard-configuration__header">
-                <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/DashboardConfiguration/Title')}</h2>
+                <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/DashboardConfiguration/Title')}</p>
                 <span>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/DashboardConfiguration/Description')}</span>
               </div>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomWidgetConfiguration/CustomWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/CustomWidgetConfiguration/CustomWidgetConfiguration.xhtml
@@ -17,7 +17,7 @@
     styleClass="card dashboard-card widget-configuration custom-widget-configuration">
     <div class="user-filter ui-g">
       <div class="ui-g-12 user-filter__header">
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</p>
         <p>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/CustomConfigurationDescription')}</p>
       </div>
     </div>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessViewerWidgetConfiguration/ProcessViewerWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessViewerWidgetConfiguration/ProcessViewerWidgetConfiguration.xhtml
@@ -18,7 +18,7 @@
     <div class="filter-container ui-g">
       <div class="ui-g-12 filter-container__header">
         <p:messages id="process-viewer-widget-validation-messages" closable="true" />
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</p>
         <p>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/processViewerConfigurationDescription')}</p>
       </div>
 

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidgetConfiguration/ProcessWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidgetConfiguration/ProcessWidgetConfiguration.xhtml
@@ -29,7 +29,7 @@
     <div class="filter-container ui-g">
       <div class="ui-g-12 filter-container__header">
         <p:messages id="process-widget-validation-messages" closable="true" />
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</p>
         <p>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/processConfigurationDescription')}</p>
       </div>
 
@@ -245,7 +245,7 @@
   <h:panelGroup id="widget-preview" styleClass="card widget-preview widget-preview--process" layout="block">
     <div class="ui-g #{isCompact ? 'widget-preview--compact' : ''} #{isFull ? 'widget-preview--full h-full' : ''} #{isCombined ? 'widget-preview--combined h-full' : ''} #{isImage ? 'widget-preview--image-width' : ''}">
       <div class="ui-g-12 widget-preview__header">
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/preview')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/preview')}</p>
         <h:outputText value="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portal/generic/dashboard/component/ProcessWidgetConfiguration/DragAndDropToChangeOrder')}" 
         rendered="#{compactDashboardProcessBean.isPreviewCustomOrder()}"/>
       </div>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeWidgetConfiguration/WelcomeWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/generic/dashboard/component/WelcomeWidgetConfiguration/WelcomeWidgetConfiguration.xhtml
@@ -20,7 +20,7 @@
   <h:panelGroup id="user-filter" layout="block" styleClass="card dashboard-card welcome-widget-configuration-panel">
     <div class="user-filter ui-g">
       <div class="ui-g-12 user-filter__header">
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</p>
         <p>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/WelcomeConfigurationDescription')}</p>
       </div>
     </div>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/AbsenceManagement/AbsenceManagement.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/AbsenceManagement/AbsenceManagement.xhtml
@@ -23,7 +23,7 @@
             <div class="ui-g portal-section-container card">
               <div class="ui-g-12 absence-management">
                 <div class="setting-header ui-g-12 u-no-padding-bottom">
-                  <h2 id="absence">#{ivy.cms.co(data.isSupervisor ? '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/allAbsences' : '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/myAbsences')}</h2>
+                  <p id="absence" class="text-style-h2">#{ivy.cms.co(data.isSupervisor ? '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/allAbsences' : '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/myAbsences')}</p>
                 </div>
 
                 <div class="ui-g-12 u-no-padding-top">
@@ -138,8 +138,8 @@
               <!-- Deputy setting ============ -->
               <div id="deputy-setting" class="ui-g-12" jsf:rendered="#{absenceManagementBean.canReadSubstitute(data.selectedAbsenceUser)}">
                 <div class="setting-header ui-g-12 u-no-padding-bottom">
-                  <h3 class="mb-0">#{ivy.cms.co(data.isSupervisor ? '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/definedDeputies'
-                    : '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/myDeputies')}</h3>
+                  <p class="mb-0 text-style-h3">#{ivy.cms.co(data.isSupervisor ? '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/definedDeputies'
+                    : '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/myDeputies')}</p>
                 </div>
                 <div id="username-deputy" class="ui-g-12 u-no-padding-top">
                   <div class="ui-g-12 pl-0">
@@ -185,8 +185,8 @@
               <!-- Deputy-For setting-->
               <div id="deputy-for-container" class="ui-g-12" jsf:rendered="#{absenceManagementBean.substitutionCapable}">
                 <div class="setting-header ui-g-12 u-no-padding-bottom">
-                  <h3 class="mb-0">#{ivy.cms.co(data.isSupervisor ? '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/selectedDeputyFor'
-                    : '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/deputyFor')}</h3>
+                  <p class="mb-0 text-style-h3">#{ivy.cms.co(data.isSupervisor ? '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/selectedDeputyFor'
+                    : '/ch.ivy.addon.portalkit.ui.jsf/AbsenceManagement/deputyFor')}</p>
                 </div>
                 <div class="ui-g-12 u-no-padding-bottom">
                   <p:dataTable id="substitution-table" rendered="#{absenceManagementBean.substitutionCapable}"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/UserProfile/UserProfile.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portal/setting/UserProfile/UserProfile.xhtml
@@ -23,7 +23,7 @@
                 <!-- General Setting -->
                 <h:panelGroup layout="block" class="w-full my-profile-block">
                   <div class="setting-header">
-                    <h5 class="font-semibold">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/General')}</h5>
+                    <p class="text-style-h5">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/General')}</p>
                   </div>
                   <p:outputLabel for="homepage" styleClass="user-profile-setting-title">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/Homepage')}</p:outputLabel >
                   <div class="ui-fluid">
@@ -36,7 +36,7 @@
                 <!-- Process List Setting -->
                 <h:panelGroup layout="block" styleClass="w-full my-profile-block" rendered="#{userProfileBean.canAccessProcessList()}">
                   <div class="setting-header">
-                    <h5 for="process-mode-selection" class="font-semibold">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/ProcessList')}</h5>
+                    <p for="process-mode-selection" class="text-style-h5">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/ProcessList')}</p>
                   </div>
                   <p:outputLabel for="process-mode-selection" styleClass="user-profile-setting-title">#{ivy.cms.co("/ch.ivy.addon.portalkit.ui.jsf/MyProfile/defaultViewMode")}</p:outputLabel>
                   <div class="ui-fluid">
@@ -49,7 +49,7 @@
                 <!-- Task Widget Setting -->
                  <h:panelGroup layout="block" styleClass="w-full my-profile-block" rendered="#{visibilityBean.enablePinTask}">
                   <div class="setting-header">
-                    <h5 class="font-semibold">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/TaskList')}</h5>
+                    <p class="text-style-h5">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/TaskList')}</p>
                   </div>
                     <p:commandButton value="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portal/setting/UserProfile/unpinAllPinnedTasks')}"
                       ariaLabel="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portal/setting/UserProfile/unpinAllPinnedTasks')}"
@@ -60,7 +60,7 @@
               <!-- Case Widget Setting -->
                  <h:panelGroup layout="block" styleClass="w-full my-profile-block" rendered="#{visibilityBean.enablePinCase}">
                   <div class="setting-header">
-                    <h5 class="font-semibold">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/CaseList')}</h5>
+                    <p class="text-style-h5">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/CaseList')}</p>
                   </div>
                     <p:commandButton value="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portal/setting/UserProfile/unpinAllPinnedCases')}"
                       ariaLabel="#{ivy.cms.co('/Dialogs/ch/ivy/addon/portal/setting/UserProfile/unpinAllPinnedCases')}"
@@ -71,7 +71,7 @@
               <!-- Accessibility Setting -->
               <h:panelGroup id="accessibility-panel" layout="block" styleClass="my-profile-block col-12 p-0">
                   <div class="setting-header">
-                    <h5 class="font-semibold">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/Accessibility')}</h5>
+                    <p class="text-style-h5">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/Accessibility')}</p>
                   </div>
                   <div class="flex align-items-center">
                     <div class="col-8 p-0">
@@ -91,7 +91,7 @@
               <div class="ui-g-6 pl-5 ui-sm-12 relative user-profile-card-right justify-content-between grid">
                 <h:panelGroup id="language-setting-container" layout="block" styleClass="w-full my-profile-block">
                   <div class="setting-header">
-                    <h5 id="language-setting-title" class="font-semibold">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/Language')}</h5>
+                    <p id="language-setting-title" class="text-style-h5">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/Language')}</p>
                   </div>
                   <!-- Language Setting -->
                   <div class="language-selection w-full">
@@ -124,7 +124,7 @@
                     </p:growl>
                   </div>
                   <div class="setting-header">
-                    <h5 class="font-semibold">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/notificationChannels')}</h5>
+                    <p class="text-style-h5">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/MyProfile/notificationChannels')}</p>
                   </div>
                   <div class="w-full">
                     <p:dataTable paginator="true" rows="10" paginatorPosition="bottom" paginatorAlwaysVisible="false" var="event"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/LoginErrorPage/LoginErrorPage.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/LoginErrorPage/LoginErrorPage.xhtml
@@ -13,13 +13,13 @@
           alt="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/loginLogo')}" />
       </div>
       <div class="login-panel-content">
-        <h4><i class="si si-alert-circle failed-message__icon"/> #{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/loginFailed')}</h4>
+        <p class="text-style-h4"><i class="si si-alert-circle failed-message__icon"/> #{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/loginFailed')}</p>
         <p>#{ivy.cms.co("/ch.ivy.addon.portalkit.ui.jsf/login/loginErrorMessage")}</p>
       </div>
     </div>
     <div class="login-footer">
-      <h4>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/AxonIvyPortal')}</h4>
-      <h6>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/Copyright')}</h6>
+      <p class="text-style-h4">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/AxonIvyPortal')}</p>
+      <p class="text-style-h6">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/login/Copyright')}</p>
     </div>
   </div>
 </cc:implementation>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/admin/AdminSettings/AdminSettings.xhtml
@@ -16,7 +16,7 @@
   <h:panelGroup styleClass="w-full pt-2 pb-2 mb-4" layout="block">
     <div class="flex justify-content-between flex-wrap">
       <div class="flex align-items-center justify-content-center admin-setting-header">
-         <h3>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/applicationMenuHeader/adminSettings')}</h3>
+         <p class="text-style-h3">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/applicationMenuHeader/adminSettings')}</p>
       </div>
       <h:panelGroup layout="block" class="applications-setting-info-circle">
         <h:outputText id="applications-setting-info" styleClass="applications-setting-info si si-information-circle" />

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemDocument/CaseItemDocument.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/CaseItemDocument/CaseItemDocument.xhtml
@@ -136,9 +136,9 @@
           <div style="display: none;" id="error-message" />
         </div>
        <div class="w-full">
-        <h6 class="import-header-title">
+        <p class="import-header-title text-style-h6">
         <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/taskDetails/supportFileTypes',[masterDataBean.allowedUploadFileType])}" />
-        </h6>
+        </p>
         </div>
         <div class="w-full">
           <p:fileUpload id="document-upload-panel"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/GlobalAjaxStatus/GlobalAjaxStatus.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/GlobalAjaxStatus/GlobalAjaxStatus.xhtml
@@ -22,7 +22,7 @@
       <div class="ajax-status-position #{cc.attrs.styleClass}">
         <div class="axonivy-loader">
           <div class="spinner" />
-          <h5>#{empty cc.attrs.startLoadingText ? ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/loading') : cc.attrs.startLoadingText}...</h5>
+          <p class="text-style-h5">#{empty cc.attrs.startLoadingText ? ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/loading') : cc.attrs.startLoadingText}...</p>
         </div>
       </div>
     </f:facet>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/RoleManagement/RoleManagement.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/RoleManagement/RoleManagement.xhtml
@@ -168,7 +168,7 @@
     <h:form id="manage-role-details-form" styleClass="manage-role-details-form MarTop5">
       <h:panelGroup styleClass="w-full" layout="block" rendered="#{roleManagementBean.canModifyRoleInformation}">
         <div class="field ">
-          <h5 class="role-management-title" >#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/components/RoleManagement/RoleInformation')}</h5>
+          <p class="role-management-title">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/components/RoleManagement/RoleInformation')}</p>
         </div>
 
         <div class="ui-g-12 u-no-padding-top u-no-padding-bottom">
@@ -221,7 +221,7 @@
 
       <h:panelGroup layout="block" styleClass="w-full" rendered="#{roleManagementBean.canModifyUserAssignment}">
         <h:panelGroup layout="block" styleClass="field mb-4 #{roleManagementBean.canModifyRoleInformation ? 'mt-5' : ''}">
-          <h5 class="role-management-title">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/components/RoleManagement/UserAssignment')}</h5>
+          <p class="role-management-title">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/components/RoleManagement/UserAssignment')}</p>
         </h:panelGroup>
 
         <h:panelGroup styleClass="field" layout="block">

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskItemDocuments/TaskItemDocuments.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/component/TaskItemDocuments/TaskItemDocuments.xhtml
@@ -135,9 +135,9 @@
           <div style="display: none;" id="error-message" />
         </div>
        <div class="w-full">
-        <h6 class="import-header-title">
+        <p class="import-header-title text-style-h6">
         <h:outputText value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/taskDetails/supportFileTypes',[masterDataBean.allowedUploadFileType])}" />
-        </h6>
+        </p>
         </div>
         <div class="w-full">
           <p:fileUpload id="document-upload-panel"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/LogoutSetting/LogoutSetting.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/multiapp/settings/LogoutSetting/LogoutSetting.xhtml
@@ -32,7 +32,7 @@
     rendered="#{data.isWorkingOnATask}" responsive="true"  closable="false" styleClass="warning-before-leaving-task">
     <f:facet name="message">
       <div class="text-center">
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/confirmation')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/confirmation')}</p>
       </div>
       <h:panelGroup layout="block">
         <h:outputText rendered="#{task.state != 'CREATED'}"

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/ForgotPassword/ForgotPassword.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/ForgotPassword/ForgotPassword.xhtml
@@ -19,7 +19,7 @@
             alt="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/loginLogo')}" />
         </div>
         <p:focus for="email" />
-        <h4>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/forgotPassword/passwordReset')}</h4>
+        <p class="text-style-h4">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/forgotPassword/passwordReset')}</p>
 
         <p:messages id="forgot-password-message" showIcon="false"/>
         <p:inputText id="email" value="#{data.email}" required="true"
@@ -43,8 +43,8 @@
         </div>
       </div>
       <h:panelGroup layout="block" class="login-footer" rendered="#{visibilityBean.showLoginFooter}">
-        <h4>#{ivy.cms.co('/Labels/Login/CompanyName')}</h4>
-        <h6>#{ivy.cms.co('/Labels/Login/Copyright')}</h6>
+        <p class="text-style-h4">#{ivy.cms.co('/Labels/Login/CompanyName')}</p>
+        <p class="text-style-h6">#{ivy.cms.co('/Labels/Login/Copyright')}</p>
       </h:panelGroup>
     </div>
   </h:form>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/Login/Login.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/Login/Login.xhtml
@@ -20,7 +20,7 @@
             alt="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/loginLogo')}" />
         </div>
         <p:focus for="username" />
-        <h4>#{cc.attrs.title}</h4>
+        <p class="text-style-h4">#{cc.attrs.title}</p>
 
         <p:messages id="login-message" showIcon="false"/>
 
@@ -60,8 +60,8 @@
         </div>
       </div>
       <h:panelGroup layout="block" class="login-footer" rendered="#{visibilityBean.showLoginFooter}">
-        <h4>#{ivy.cms.co('/Labels/Login/CompanyName')}</h4>
-        <h6>#{ivy.cms.co('/Labels/Login/Copyright')}</h6>
+        <p class="text-style-h4">#{ivy.cms.co('/Labels/Login/CompanyName')}</p>
+        <p class="text-style-h6">#{ivy.cms.co('/Labels/Login/Copyright')}</p>
       </h:panelGroup>
     </div>
   </h:form>

--- a/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/PasswordReset/PasswordReset.xhtml
+++ b/AxonIvyPortal/portal/src_hd/ch/ivy/addon/portalkit/singleapp/general/PasswordReset/PasswordReset.xhtml
@@ -15,7 +15,7 @@
     <div class="ui-g">
       <h:panelGroup rendered="#{!data.resetSuccess}">
         <div class="ui-g-12">
-          <h4>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/forgotPassword/setANewPassword')}</h4>
+          <p class="text-style-h4">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/forgotPassword/setANewPassword')}</p>
         </div>
         <h:panelGroup styleClass="block" class="ui-g-12">
           <p:messages id="password-reset-message" />
@@ -51,7 +51,7 @@
       </h:panelGroup>
       <h:panelGroup id="result-message" rendered="#{data.resetSuccess}">
         <div class="ui-g-12 result-message">
-          <h4><i class="si si-check-circle result-message__icon" /> #{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/forgotPassword/passwordReset')}</h4>
+          <p class="text-style-h4"><i class="si si-check-circle result-message__icon" /> #{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/forgotPassword/passwordReset')}</p>
           <h:outputText escape="false" value="#{htmlSanitizerBean.sanitize(data.message)}" />
         </div>
         <div class="ui-g-12">

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/DashboardImportDetails/DashboardImportDetails.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/DashboardImportDetails/DashboardImportDetails.xhtml
@@ -31,7 +31,7 @@
       <h:panelGroup id="dashboard-upload-panel" layout="block"
         styleClass="ui-g">
         <div class="ui-g-12">
-          <h5 class="import-header-title"><h:outputText value="#{ivy.cms.co('/Dialogs/com/axonivy/portal/dashboard/component/DashboardImportDetails/chooseAJsonFile')}" /></h5>
+          <p class="import-header-title text-style-h5"><h:outputText value="#{ivy.cms.co('/Dialogs/com/axonivy/portal/dashboard/component/DashboardImportDetails/chooseAJsonFile')}" /></p>
         </div>
         <div class="ui-g-12">
           <p:fileUpload id="dashboard-upload" chooseIcon="#{visibilityBean.generateButtonIcon('si si-touchpad-finger')}"

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NewsWidget/ManageNews.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NewsWidget/ManageNews.xhtml
@@ -122,7 +122,7 @@
     value="#{ivy.cms.co('/Dialogs/com/axonivy/portal/dashboard/component/NewsWidget/RemoveNewsHeader')}" />
   <ui:define name="dialogContentSection">
     <div class="text-center">
-      <h5>"#{newsWidgetBean.selectedNews.name}"</h5>
+      <p class="text-style-h5">"#{newsWidgetBean.selectedNews.name}"</p>
       <p>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/removeWidgetMessage')}</p>
     </div>
   </ui:define>

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NewsWidgetConfiguration/NewsWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NewsWidgetConfiguration/NewsWidgetConfiguration.xhtml
@@ -16,7 +16,7 @@
   <h:panelGroup id="filter-container" layout="block" styleClass="card dashboard-card widget-configuration news-widget-configuration">
     <div class="filter-container ui-g">
       <div id="news-widget-configuration-header" class="ui-g-12 filter-container__header">
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</p>
         <p>#{ivy.cms.co('/Dialogs/com/axonivy/portal/dashboard/component/NewsWidgetConfiguration/NewsWidgetDescription')}</p>
       </div>
 

--- a/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NotificationWidgetConfiguration/NotificationWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/src_hd/com/axonivy/portal/dashboard/component/NotificationWidgetConfiguration/NotificationWidgetConfiguration.xhtml
@@ -23,7 +23,7 @@
     <div class="user-filter ui-g">
       <div id="notification-widget-configuration-header"
         class="ui-g-12 user-filter__header">
-        <h2>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</h2>
+        <p class="text-style-h2">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</p>
         <p>#{ivy.cms.co('/Dialogs/com/axonivy/portal/dashboard/component/NotificationWidgetConfiguration/NotificationWidgetDescription')}</p>
       </div>
 

--- a/AxonIvyPortal/portal/webContent/layouts/decorator/portal-dialog-with-icon.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/decorator/portal-dialog-with-icon.xhtml
@@ -19,7 +19,7 @@
   pt:aria-labelledby="#{not empty id ? id : widgetVar}-dialog-title">
   
   <div class="text-center">
-    <h3 id="#{not empty id ? id : widgetVar}-dialog-title">#{not empty headerText? headerText : ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/confirmationHeaderText')}</h3>
+    <p id="#{not empty id ? id : widgetVar}-dialog-title" class="text-style-h3">#{not empty headerText? headerText : ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/common/confirmationHeaderText')}</p>
   </div>
   
   <ui:insert name="dialogContentSection" />

--- a/AxonIvyPortal/portal/webContent/layouts/includes/progress-loader.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/includes/progress-loader.xhtml
@@ -5,7 +5,7 @@
     <f:facet name="start">
       <div class="axonivy-loader">
         <div class="spinner"></div>
-        <h5>Loading...</h5>
+        <p class="text-style-h5">Loading...</p>
       </div>
     </f:facet>
     <f:facet name="complete">

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/DashboardTemplate.xhtml
@@ -161,14 +161,14 @@
               </c:forEach>
             </c:if>
             <h:panelGroup rendered="#{managedBean.selectedDashboard == null and managedBean.isEditMode}">
-              <h1 class="ui-g-12">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/noDashboard')}</h1>
+              <p class="ui-g-12 text-style-h1" role="status">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/noDashboard')}</p>
             </h:panelGroup>
             <h:panelGroup rendered="#{managedBean.selectedDashboard == null and not managedBean.isEditMode}">
-              <h1 class="ui-g-12">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/noPermission')}</h1>
+              <p class="ui-g-12 text-style-h1" role="status">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/noPermission')}</p>
             </h:panelGroup>
             <h:panelGroup
               rendered="#{managedBean.selectedDashboard != null and empty managedBean.selectedDashboard.widgets}">
-              <h1 class="ui-g-12">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/noWidget')}</h1>
+              <p class="ui-g-12 text-style-h1" role="status">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/noWidget')}</p>
             </h:panelGroup>
             <ui:insert name="dashboardContent" />
           </h:panelGroup>

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/SidebarWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/SidebarWidgetConfiguration.xhtml
@@ -17,7 +17,7 @@
 <h:panelGroup id="widget-preview" styleClass="card table-configuration u-hidden-sm-down" layout="block">
   <div class="ui-g">
     <div class="ui-g-12 widget-preview__header">
-      <h4>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/tableConfiguration')}</h4>
+      <p class="text-style-h4">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/tableConfiguration')}</p>
     </div>
     
     <h:panelGroup id="widget-title-group"
@@ -63,12 +63,12 @@
         value="#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/components/taskView/filter')}"
         type="button" onclick="openFilterPanel(event);"/>
     </div>
-    
+
     <p:overlayPanel id="widget-configuration-panel" for="widget-configuration-button"
           styleClass="widget-configuration-overlaypanel" widgetVar="widgetConfigurationPanel" appendTo="@(body)"
           dynamic="true"
           my="right top" at="right bottom">
-      <h4 class="widget-configuration-section-header">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/displaySettings')}</h4>
+      <p class="widget-configuration-section-header">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/displaySettings')}</p>
       <h:panelGroup id="quick-search-group" layout="block"
         rendered="#{managedBean.canEnableQuickSearch()}"
         styleClass="widget-configuration-group-item ui-fluid flex">
@@ -137,7 +137,7 @@
 
       <!-- Case Query Type Selector (Case Widget only) -->
       <h:panelGroup rendered="#{widget.type eq 'CASE'}">
-        <h4 class="widget-configuration-section-header separator-top">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/dataSettings')}</h4>
+        <p class="widget-configuration-section-header separator-top">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/dataSettings')}</p>
       </h:panelGroup>
       <h:panelGroup id="case-query-type-group"
         rendered="#{widget.type eq 'CASE'}"
@@ -174,7 +174,7 @@
   <h:panelGroup id="widget-filter-content" layout="block" styleClass="filter-panel js-filter-panel" >
       <div class="ui-g ui-g-12 MarTop20 filter-panel-header">
         <div class="ui-g-4 ui-md-5">
-          <h4 class="filter-panel-title">#{ivy.cms.co("/ch.ivy.addon.portalkit.ui.jsf/dashboard/filters")}</h4>
+          <p class="filter-panel-title text-style-h4">#{ivy.cms.co("/ch.ivy.addon.portalkit.ui.jsf/dashboard/filters")}</p>
         </div>
         <div class="ui-g-8 ui-md-7">
           <p:remoteCommand id="updateComponentOnPreviewCmd" name="updateComponentOnPreviewCmd"

--- a/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/TableWidgetConfiguration.xhtml
+++ b/AxonIvyPortal/portal/webContent/layouts/restricted/decorator/TableWidgetConfiguration.xhtml
@@ -15,7 +15,7 @@
 <h:panelGroup id="filter-container" layout="block" styleClass="card dashboard-card widget-configuration #{filterContainerStyleClass}">
   <div class="filter-container ui-g dashboard-configuration-filter-container">
     <div class="ui-g-12 filter-container__header">
-      <h4>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</h4>
+      <p class="text-style-h4">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configuration')}</p>
       <p>
         #{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/configurationDescription')}
       </p>
@@ -69,7 +69,7 @@
 <h:panelGroup id="widget-preview" styleClass="card widget-preview u-hidden-sm-down" layout="block">
   <div class="ui-g">
     <div class="ui-g-12 widget-preview__header">
-      <h4>#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/tableConfiguration')}</h4>
+      <p class="text-style-h4">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/tableConfiguration')}</p>
       <p class="widget-preview__header--description">#{ivy.cms.co('/ch.ivy.addon.portalkit.ui.jsf/dashboard/configuration/tableConfigurationDesc')}</p>
     </div>
 

--- a/AxonIvyPortal/portal/webContent/resources/css/dashboard.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/dashboard.css
@@ -636,8 +636,8 @@ body .ui-selectcheckboxmenu.task-configuration__selectcheckboxmenu .ui-selectche
   align-self: flex-start;
 }
 
-.filter-container__header h2,
-.widget-preview__header h2 {
+.filter-container__header p.text-style-h2,
+.widget-preview__header p.text-style-h2 {
   margin: auto;
 }
 
@@ -1003,6 +1003,7 @@ body .ui-widget.new-widget-dialog__introduction {
   padding: 0.5rem 1rem;
   font-size: 0.9rem;
   font-weight: 600;
+  line-height: 1.2;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-color-secondary);

--- a/AxonIvyPortal/portal/webContent/resources/css/module.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/module.css
@@ -27,6 +27,15 @@
  *
  */
 
+/* Must stay above every .container p override below: the Freya theme's bare
+   `p:last-child { margin-bottom: 0 }` rule ties this on specificity (:where()
+   contributes none), so source order decides — container-specific overrides
+   further down this cascade (e.g. .header-process-name p, .dashboard-configuration__header p)
+   need to win that tie, not this default. */
+p:where(.text-style-h1, .text-style-h2, .text-style-h3, .text-style-h4, .text-style-h5, .text-style-h6):last-child {
+  margin-bottom: 1rem;
+}
+
 .portal-edit-inplace span.ui-inplace-editor {
   display: inline-block;
 }
@@ -3182,7 +3191,7 @@ _:-ms-fullscreen, :root .new-absence-messages .ui-messages-error {
   height: 100%;
 }
 
-.dashboard-configuration__header h2,
+.dashboard-configuration__header p,
 .my-profile-container .setting-header h2 {
   padding: 0;
   margin-bottom: .5rem;
@@ -5438,7 +5447,7 @@ body.light .image-process-container .image-process-item .card-item.card.image-wi
   align-items: center;
 }
 
-.header-process-name h2 {
+.header-process-name p {
   margin: 0;
 }
 
@@ -5706,7 +5715,36 @@ a.dashboard-action-container label {
 .role-management-title {
   margin: auto;
   font-size: 16px;
+  font-weight: 600;
+  line-height: 1.2;
 }
+
+/* =================== HEADING-REPLICA TEXT STYLES ======================
+   Used on <p> elements that replaced a former heading tag (h1-h6) so that
+   text keeps the exact size/weight/spacing the heading tag used to have,
+   per the theme's base heading rule:
+   h1,h2,h3,h4,h5,h6 { margin:1.5rem 0 1rem 0; font-weight:600; line-height:1.2; }
+   h1..h6:first-child { margin-top:0; }
+   h1 2.5rem / h2 2rem / h3 1.75rem / h4 1.5rem / h5 1.25rem / h6 1rem
+*/
+.text-style-h1, .text-style-h2, .text-style-h3,
+.text-style-h4, .text-style-h5, .text-style-h6 {
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 1.2;
+  color: inherit;
+  margin: 1.5rem 0 1rem 0;
+}
+.text-style-h1:first-child, .text-style-h2:first-child, .text-style-h3:first-child,
+.text-style-h4:first-child, .text-style-h5:first-child, .text-style-h6:first-child {
+  margin-top: 0;
+}
+.text-style-h1 { font-size: 2.5rem; }
+.text-style-h2 { font-size: 2rem; }
+.text-style-h3 { font-size: 1.75rem; }
+.text-style-h4 { font-size: 1.5rem; }
+.text-style-h5 { font-size: 1.25rem; }
+.text-style-h6 { font-size: 1rem; }
 
 .role-details-header {
   font-size: large;

--- a/AxonIvyPortal/portal/webContent/resources/css/portal-variables-dark.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/portal-variables-dark.css
@@ -363,4 +363,7 @@
   
     /* Leave task warning message*/
   --warning-before-leave-task: var(--ivy-primary-color-grey-medium);
+
+  /* Login footer copyright text */
+  --login-footer-copyright-color: #BFC2C6;
 }

--- a/AxonIvyPortal/portal/webContent/resources/css/portal-variables-light.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/portal-variables-light.css
@@ -373,4 +373,7 @@
   
   /* Leave task warning message*/
   --warning-before-leave-task: #757575;
+
+  /* Login footer copyright text */
+  --login-footer-copyright-color: rgba(41, 50, 65, 0.5);
 }

--- a/AxonIvyPortal/portal/webContent/resources/css/portal.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/portal.css
@@ -1431,8 +1431,29 @@ body.in-dialog .ui-widget-overlay {
   line-height: 1.2;
 }
 
-.axonivy-loader h5 {
+.axonivy-loader p {
   color: var(--ajax-loader-color);
+  margin-top: 5px;
+  text-align: center;
+  font-size: 1em;
+}
+
+.login-body .login-wrapper .login-panel > p.text-style-h4 {
+  font-weight: 600;
+  margin: 1.5rem 0 1rem 0;
+  color: inherit;
+}
+
+.login-footer p.text-style-h4 {
+  line-height: 22px;
+  margin: 0 32px 0 0;
+}
+
+.login-footer p.text-style-h6 {
+  line-height: 17px;
+  margin: 0;
+  color: rgba(41, 50, 65, 0.5);
+  font-weight: 500;
 }
 
 .result-message__icon {

--- a/AxonIvyPortal/portal/webContent/resources/css/portal.css
+++ b/AxonIvyPortal/portal/webContent/resources/css/portal.css
@@ -1452,7 +1452,7 @@ body.in-dialog .ui-widget-overlay {
 .login-footer p.text-style-h6 {
   line-height: 17px;
   margin: 0;
-  color: rgba(41, 50, 65, 0.5);
+  color: var(--login-footer-copyright-color);
   font-weight: 500;
 }
 


### PR DESCRIPTION
## Summary
- Converts `<h2>`-`<h6>` tags that had no accompanying `<h1>` on the assembled page into `<p class="text-style-hN">`, preserving the exact prior visual size/weight/spacing (no UI change).
- Adds reusable `.text-style-h1`-`.text-style-h6` classes to `module.css` mirroring the theme's heading font-size scale.
- Fixes a few CSS specificity issues surfaced by the retagging (dead `hN`-scoped selectors renamed to `p`-scoped, a `p:last-child` collision, theme `.login-footer` tie-ins).