### PR TITLE
Migrate to process-extension-api 🐫️

### DIFF
--- a/AxonIvyPortal/portal/pom.xml
+++ b/AxonIvyPortal/portal/pom.xml
@@ -64,8 +64,8 @@
       <artifactId>ivy-translation-service-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.axonivy.ivy.spi</groupId>
-      <artifactId>ivy-process-extension-spi</artifactId>
+      <groupId>com.axonivy.ivy.api.extension</groupId>
+      <artifactId>ivy-process-extension-api</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/Showcase/portal-developer-examples/pom.xml
+++ b/Showcase/portal-developer-examples/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.axonivy.ivy.spi</groupId>
-      <artifactId>ivy-process-extension-spi</artifactId>
+      <groupId>com.axonivy.ivy.api.extension</groupId>
+      <artifactId>ivy-process-extension-api</artifactId>
     </dependency>
   </dependencies>
   <repositories>

--- a/Showcase/portal-user-examples/pom.xml
+++ b/Showcase/portal-user-examples/pom.xml
@@ -36,8 +36,8 @@
       <artifactId>ivy-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.axonivy.ivy.spi</groupId>
-      <artifactId>ivy-process-extension-spi</artifactId>
+      <groupId>com.axonivy.ivy.api.extension</groupId>
+      <artifactId>ivy-process-extension-api</artifactId>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
The -spi variant is legacy, and will be soon dropped from ivy-project-parent.
The new is equally powerful, but contains less deprecated APIs.
However, you didn't use any of the removed methods ... 